### PR TITLE
fix: hide play/watcher/favorite stats for unreleased media

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/info/EpisodeInfoView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/info/EpisodeInfoView.kt
@@ -64,7 +64,7 @@ private fun EpisodeInfoView(
                     lists = state.episodeStats?.lists ?: 0,
                     favorites = null,
                     loading = !state.loading.isDone,
-                    isReleased = episode.isReleased,
+                    released = episode.isReleased,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 23.dp),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/info/EpisodeInfoView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/info/EpisodeInfoView.kt
@@ -64,6 +64,7 @@ private fun EpisodeInfoView(
                     lists = state.episodeStats?.lists ?: 0,
                     favorites = null,
                     loading = !state.loading.isDone,
+                    isReleased = episode.isReleased,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 23.dp),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/info/MovieInfoView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/info/MovieInfoView.kt
@@ -66,7 +66,7 @@ private fun MovieInfoView(
                     lists = state.movieStats?.lists ?: 0,
                     favorites = state.movieStats?.favorited ?: 0,
                     loading = !state.loading.isDone,
-                    isReleased = it.isReleased,
+                    released = it.isReleased,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 23.dp),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/info/MovieInfoView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/info/MovieInfoView.kt
@@ -66,6 +66,7 @@ private fun MovieInfoView(
                     lists = state.movieStats?.lists ?: 0,
                     favorites = state.movieStats?.favorited ?: 0,
                     loading = !state.loading.isDone,
+                    isReleased = it.isReleased,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 23.dp),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/info/ShowInfoView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/info/ShowInfoView.kt
@@ -66,7 +66,7 @@ private fun ShowInfoView(
                     lists = state.showStats?.lists ?: 0,
                     favorites = state.showStats?.favorited ?: 0,
                     loading = !state.loading.isDone,
-                    isReleased = it.isReleased,
+                    released = it.isReleased,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 23.dp),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/info/ShowInfoView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/info/ShowInfoView.kt
@@ -66,6 +66,7 @@ private fun ShowInfoView(
                     lists = state.showStats?.lists ?: 0,
                     favorites = state.showStats?.favorited ?: 0,
                     loading = !state.loading.isDone,
+                    isReleased = it.isReleased,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 23.dp),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/ui/views/info/MetaView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/ui/views/info/MetaView.kt
@@ -23,13 +23,17 @@ internal fun MetaView(
     favorites: Int?,
     loading: Boolean,
     modifier: Modifier = Modifier,
+    isReleased: Boolean = true,
 ) {
+    val displayedPlays = if (isReleased) plays else 0
+    val displayedWatchers = if (isReleased) watchers else 0
+    val displayedFavorites = favorites?.let { if (isReleased) it else 0 }
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
     ) {
         MetaViewItemView(
-            title = rememberThousandsFormat(plays),
+            title = rememberThousandsFormat(displayedPlays),
             subtitle = stringResource(R.string.stat_text_plays),
             icon = {
                 Icon(
@@ -49,7 +53,7 @@ internal fun MetaView(
         )
 
         MetaViewItemView(
-            title = rememberThousandsFormat(watchers),
+            title = rememberThousandsFormat(displayedWatchers),
             subtitle = stringResource(R.string.stat_text_watchers),
             icon = {
                 Icon(
@@ -80,9 +84,9 @@ internal fun MetaView(
                 .weight(1F),
         )
 
-        favorites?.let {
+        displayedFavorites?.let { favoritesValue ->
             MetaViewItemView(
-                title = rememberThousandsFormat(favorites),
+                title = rememberThousandsFormat(favoritesValue),
                 subtitle = stringResource(R.string.stat_text_favorited),
                 icon = {
                     Icon(

--- a/app/src/main/java/tv/trakt/trakt/core/summary/ui/views/info/MetaView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/ui/views/info/MetaView.kt
@@ -17,23 +17,20 @@ import tv.trakt.trakt.ui.theme.TraktTheme
 
 @Composable
 internal fun MetaView(
+    released: Boolean,
     plays: Int,
     watchers: Int,
     lists: Int,
     favorites: Int?,
     loading: Boolean,
     modifier: Modifier = Modifier,
-    isReleased: Boolean = true,
 ) {
-    val displayedPlays = if (isReleased) plays else 0
-    val displayedWatchers = if (isReleased) watchers else 0
-    val displayedFavorites = favorites?.let { if (isReleased) it else 0 }
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
     ) {
         MetaViewItemView(
-            title = rememberThousandsFormat(displayedPlays),
+            title = rememberThousandsFormat(if (released) plays else 0),
             subtitle = stringResource(R.string.stat_text_plays),
             icon = {
                 Icon(
@@ -53,7 +50,7 @@ internal fun MetaView(
         )
 
         MetaViewItemView(
-            title = rememberThousandsFormat(displayedWatchers),
+            title = rememberThousandsFormat(if (released) watchers else 0),
             subtitle = stringResource(R.string.stat_text_watchers),
             icon = {
                 Icon(
@@ -84,9 +81,9 @@ internal fun MetaView(
                 .weight(1F),
         )
 
-        displayedFavorites?.let { favoritesValue ->
+        favorites?.let {
             MetaViewItemView(
-                title = rememberThousandsFormat(favoritesValue),
+                title = rememberThousandsFormat(if (released) it else 0),
                 subtitle = stringResource(R.string.stat_text_favorited),
                 icon = {
                     Icon(
@@ -118,6 +115,7 @@ private fun Preview() {
             lists = 321,
             favorites = 987,
             loading = false,
+            released = true,
         )
     }
 }
@@ -136,6 +134,7 @@ private fun PreviewLoading() {
             lists = 0,
             favorites = 0,
             loading = true,
+            released = true,
         )
     }
 }

--- a/common/src/main/java/tv/trakt/trakt/common/model/Show.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/model/Show.kt
@@ -6,6 +6,7 @@ import androidx.core.graphics.toColorInt
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.Serializable
+import tv.trakt.trakt.common.helpers.extensions.isNowOrBefore
 import tv.trakt.trakt.common.helpers.extensions.toZonedDateTime
 import tv.trakt.trakt.common.helpers.serializers.ImmutableListSerializer
 import tv.trakt.trakt.common.helpers.serializers.ZonedDateTimeSerializer
@@ -44,6 +45,15 @@ data class Show(
     val languages: ImmutableList<String>,
 ) {
     companion object
+
+    // Considered released if status is "released" or release date is today or before
+    val isReleased: Boolean
+        get() {
+            if (status == MediaStatus.Released) {
+                return true
+            }
+            return released?.isNowOrBefore() == true
+        }
 }
 
 fun Companion.fromDto(dto: ShowDto): Show {

--- a/common/src/main/java/tv/trakt/trakt/common/model/Show.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/model/Show.kt
@@ -10,6 +10,7 @@ import tv.trakt.trakt.common.helpers.extensions.isNowOrBefore
 import tv.trakt.trakt.common.helpers.extensions.toZonedDateTime
 import tv.trakt.trakt.common.helpers.serializers.ImmutableListSerializer
 import tv.trakt.trakt.common.helpers.serializers.ZonedDateTimeSerializer
+import tv.trakt.trakt.common.model.MediaStatus.Released
 import tv.trakt.trakt.common.model.Show.Companion
 import tv.trakt.trakt.common.networking.RecommendedShowDto
 import tv.trakt.trakt.common.networking.ShowDto
@@ -48,12 +49,7 @@ data class Show(
 
     // Considered released if status is "released" or release date is today or before
     val isReleased: Boolean
-        get() {
-            if (status == MediaStatus.Released) {
-                return true
-            }
-            return released?.isNowOrBefore() == true
-        }
+        get() = status == Released || released?.isNowOrBefore() == true
 }
 
 fun Companion.fromDto(dto: ShowDto): Show {


### PR DESCRIPTION
## Summary

- Mirrors the rating hide pattern across `MovieDetailsHeader` / `ShowDetailsHeader` / `EpisodeDetailsHeader`. Unreleased movies, shows, and episodes now zero out plays/watchers/favorites in `MetaView` instead of surfacing whatever the API reports.
- List counts are preserved across the aired/unaired boundary - those reflect legitimate user anticipation rather than playback abuse.
- Added `Show.isReleased` to match `Movie.isReleased` / `Episode.isReleased`, so the three info views can pass a single flag into `MetaView`.

## Test plan

- [x] `:app:compileDebugKotlin` and `:common:compileDebugKotlin` succeed
- [ ] Manual verify: open an unreleased movie/show/episode, confirm plays/watchers/favorites render as 0 while list count stays
- [ ] Manual verify: released movie with future air date (status=released) still shows real stats

Companion to https://github.com/trakt/trakt-web/pull/2366.