### PR TITLE
feat(app): show ends-at time in check-in toast expanded view

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/checkin/data/service/CheckInService.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/checkin/data/service/CheckInService.kt
@@ -13,6 +13,7 @@ import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
 import android.os.Build
 import android.os.IBinder
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
@@ -36,6 +37,7 @@ import tv.trakt.trakt.common.helpers.extensions.durationFormat
 import tv.trakt.trakt.common.helpers.extensions.getHttpCode
 import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
 import tv.trakt.trakt.common.helpers.extensions.rethrowCancellation
+import tv.trakt.trakt.common.helpers.extensions.toLocal
 import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
 import tv.trakt.trakt.common.model.MediaType
 import tv.trakt.trakt.common.model.toTraktId
@@ -50,6 +52,9 @@ import tv.trakt.trakt.core.summary.movies.features.trivia.usecases.GetMovieTrivi
 import tv.trakt.trakt.core.summary.shows.features.trivia.usecases.GetShowTriviaUseCase
 import tv.trakt.trakt.resources.R
 import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
 import kotlin.math.roundToLong
 import kotlin.time.Duration.Companion.seconds
 
@@ -137,6 +142,13 @@ internal class CheckInService : Service() {
         val minutesLeft = ((expiresAt - now) / 60F).roundToLong().coerceAtLeast(1)
         val secondsLeft = (expiresAt - now).coerceAtLeast(0)
 
+        val locale = AppCompatDelegate.getApplicationLocales().get(0) ?: Locale.getDefault()
+        val endsAt = data.expiresAt.toLocal().format(
+            DateTimeFormatter
+                .ofLocalizedTime(FormatStyle.SHORT)
+                .withLocale(locale),
+        )
+
         // Ensure progress is at least 1 to show the progress bar
         val normalizedProgress = progress.toInt().coerceIn(1, 100)
         val contentText = when {
@@ -144,13 +156,15 @@ internal class CheckInService : Service() {
             else -> getString(R.string.tag_text_remaining_duration, "<${1L.durationFormat()}")
         }
 
+        val endsAtText = getString(R.string.text_ends_at, endsAt)
+
         val notification = NotificationCompat
             .Builder(applicationContext, TraktNotificationChannel.CHECK_IN.id)
             .setForegroundServiceBehavior(FOREGROUND_SERVICE_IMMEDIATE)
             .setSmallIcon(R.drawable.ic_trakt_icon_notification)
             .setSubText(getString(R.string.button_text_checkin).uppercaseWords())
             .setContentTitle(data.title)
-            .setContentText(contentText)
+            .setContentText("$endsAtText ($contentText)")
             .setShowWhen(false)
             .setAutoCancel(false)
             .setProgress(100, normalizedProgress, false)

--- a/app/src/main/java/tv/trakt/trakt/core/checkin/ui/CheckInView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/checkin/ui/CheckInView.kt
@@ -65,6 +65,7 @@ import tv.trakt.trakt.common.helpers.extensions.onClick
 import tv.trakt.trakt.common.helpers.extensions.onEmptyClick
 import tv.trakt.trakt.common.helpers.extensions.rememberDurationFormat
 import tv.trakt.trakt.common.helpers.extensions.timeFormat
+import tv.trakt.trakt.common.helpers.extensions.toLocal
 import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
 import tv.trakt.trakt.common.ui.theme.colors.Red400
 import tv.trakt.trakt.common.ui.theme.colors.Shade300
@@ -73,7 +74,6 @@ import tv.trakt.trakt.ui.components.confirmation.ConfirmationSheet
 import tv.trakt.trakt.ui.theme.HorizontalCheckInImageAspectRatio
 import tv.trakt.trakt.ui.theme.TraktTheme
 import java.time.Instant
-import java.time.ZoneId
 import kotlin.math.roundToLong
 import kotlin.time.Duration.Companion.minutes
 
@@ -106,8 +106,8 @@ internal fun CheckInView(
     onDismiss: () -> Unit = {},
 ) {
     var confirmClose by remember { mutableStateOf(false) }
-
     var timestamp by remember { mutableStateOf(nowUtcInstant()) }
+    var endsAtMode by rememberSaveable { mutableStateOf(true) }
 
     val totalSeconds = remember(startedAt, expiresAt) {
         if (startedAt != null && expiresAt != null) {
@@ -180,6 +180,7 @@ internal fun CheckInView(
                 image = image,
                 title = title,
                 subtitle = subtitle,
+                endsAtMode = endsAtMode,
                 totalDurationSeconds = { totalSeconds },
                 durationSeconds = { secondsLeft },
                 durationMinutes = { minutesLeft },
@@ -187,6 +188,7 @@ internal fun CheckInView(
                 onMediaClick = onMediaClick,
                 onCollapseClick = onCollapseClick,
                 onCloseClick = { confirmClose = true },
+                onEndsAtClick = { endsAtMode = !endsAtMode },
                 modifier = Modifier.padding(viewPadding),
             )
         } else {
@@ -227,6 +229,7 @@ private fun ExpandedView(
     image: String?,
     title: String?,
     subtitle: String?,
+    endsAtMode: Boolean,
     totalDurationSeconds: () -> Long,
     durationSeconds: () -> Long,
     durationMinutes: () -> Long,
@@ -235,6 +238,7 @@ private fun ExpandedView(
     onMediaClick: () -> Unit = {},
     onCollapseClick: () -> Unit = {},
     onCloseClick: () -> Unit = {},
+    onEndsAtClick: () -> Unit = {},
 ) {
     Box(
         modifier = modifier,
@@ -314,29 +318,35 @@ private fun ExpandedView(
 
                         val timeFormatter = timeFormat()
                         val endsAtText = remember(expiresAt, timeFormatter) {
-                            expiresAt
-                                ?.atZone(ZoneId.systemDefault())
-                                ?.toLocalTime()
-                                ?.format(timeFormatter)
+                            expiresAt?.toLocal()?.format(timeFormatter)
                         }
 
                         Column(
                             horizontalAlignment = Alignment.End,
-                            modifier = Modifier.padding(start = 16.dp, end = 0.5.dp),
-                        ) {
-                            Text(
-                                text = stringResource(R.string.tag_text_remaining_duration, durationText),
-                                textAlign = TextAlign.End,
-                                color = TraktTheme.colors.textSecondary,
-                                style = TraktTheme.typography.cardSubtitle.copy(
-                                    fontSize = 11.sp,
+                            modifier = Modifier
+                                .padding(
+                                    start = 16.dp,
+                                    end = 0.5.dp,
+                                )
+                                .onClick(
+                                    onClick = onEndsAtClick,
+                                    throttle = false,
                                 ),
-                                maxLines = 1,
-                                overflow = Ellipsis,
-                            )
-                            endsAtText?.let {
+                        ) {
+                            if (endsAtMode && !endsAtText.isNullOrBlank()) {
                                 Text(
-                                    text = stringResource(R.string.text_ends_at, it),
+                                    text = stringResource(R.string.text_ends_at, endsAtText),
+                                    textAlign = TextAlign.End,
+                                    color = TraktTheme.colors.textSecondary,
+                                    style = TraktTheme.typography.cardSubtitle.copy(
+                                        fontSize = 11.sp,
+                                    ),
+                                    maxLines = 1,
+                                    overflow = Ellipsis,
+                                )
+                            } else {
+                                Text(
+                                    text = stringResource(R.string.tag_text_remaining_duration, durationText),
                                     textAlign = TextAlign.End,
                                     color = TraktTheme.colors.textSecondary,
                                     style = TraktTheme.typography.cardSubtitle.copy(
@@ -614,6 +624,7 @@ private fun Preview() {
                         image = "",
                         title = "Stranger Things",
                         subtitle = "Season 2 - Episode 5",
+                        endsAtMode = true,
                         totalDurationSeconds = { minutesTotal.minutes.inWholeSeconds },
                         durationSeconds = { minutesLeft.minutes.inWholeSeconds },
                         durationMinutes = { minutesLeft.minutes.inWholeMinutes },

--- a/app/src/main/java/tv/trakt/trakt/core/checkin/ui/CheckInView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/checkin/ui/CheckInView.kt
@@ -64,6 +64,7 @@ import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
 import tv.trakt.trakt.common.helpers.extensions.onClick
 import tv.trakt.trakt.common.helpers.extensions.onEmptyClick
 import tv.trakt.trakt.common.helpers.extensions.rememberDurationFormat
+import tv.trakt.trakt.common.helpers.extensions.timeFormat
 import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
 import tv.trakt.trakt.common.ui.theme.colors.Red400
 import tv.trakt.trakt.common.ui.theme.colors.Shade300
@@ -72,6 +73,7 @@ import tv.trakt.trakt.ui.components.confirmation.ConfirmationSheet
 import tv.trakt.trakt.ui.theme.HorizontalCheckInImageAspectRatio
 import tv.trakt.trakt.ui.theme.TraktTheme
 import java.time.Instant
+import java.time.ZoneId
 import kotlin.math.roundToLong
 import kotlin.time.Duration.Companion.minutes
 
@@ -181,6 +183,7 @@ internal fun CheckInView(
                 totalDurationSeconds = { totalSeconds },
                 durationSeconds = { secondsLeft },
                 durationMinutes = { minutesLeft },
+                expiresAt = expiresAt,
                 onMediaClick = onMediaClick,
                 onCollapseClick = onCollapseClick,
                 onCloseClick = { confirmClose = true },
@@ -227,6 +230,7 @@ private fun ExpandedView(
     totalDurationSeconds: () -> Long,
     durationSeconds: () -> Long,
     durationMinutes: () -> Long,
+    expiresAt: Instant?,
     modifier: Modifier = Modifier,
     onMediaClick: () -> Unit = {},
     onCollapseClick: () -> Unit = {},
@@ -308,18 +312,41 @@ private fun ExpandedView(
                             else -> "<${rememberDurationFormat(1)}"
                         }
 
-                        Text(
-                            text = stringResource(R.string.tag_text_remaining_duration, durationText),
-                            textAlign = TextAlign.End,
-                            color = TraktTheme.colors.textSecondary,
-                            style = TraktTheme.typography.cardSubtitle.copy(
-                                fontSize = 11.sp,
-                            ),
-                            maxLines = 2,
-                            overflow = Ellipsis,
-                            modifier = Modifier
-                                .padding(start = 16.dp, end = 0.5.dp),
-                        )
+                        val timeFormatter = timeFormat()
+                        val endsAtText = remember(expiresAt, timeFormatter) {
+                            expiresAt
+                                ?.atZone(ZoneId.systemDefault())
+                                ?.toLocalTime()
+                                ?.format(timeFormatter)
+                        }
+
+                        Column(
+                            horizontalAlignment = Alignment.End,
+                            modifier = Modifier.padding(start = 16.dp, end = 0.5.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.tag_text_remaining_duration, durationText),
+                                textAlign = TextAlign.End,
+                                color = TraktTheme.colors.textSecondary,
+                                style = TraktTheme.typography.cardSubtitle.copy(
+                                    fontSize = 11.sp,
+                                ),
+                                maxLines = 1,
+                                overflow = Ellipsis,
+                            )
+                            endsAtText?.let {
+                                Text(
+                                    text = stringResource(R.string.text_ends_at, it),
+                                    textAlign = TextAlign.End,
+                                    color = TraktTheme.colors.textSecondary,
+                                    style = TraktTheme.typography.cardSubtitle.copy(
+                                        fontSize = 11.sp,
+                                    ),
+                                    maxLines = 1,
+                                    overflow = Ellipsis,
+                                )
+                            }
+                        }
                     }
 
                     LinearProgressIndicator(
@@ -590,6 +617,7 @@ private fun Preview() {
                         totalDurationSeconds = { minutesTotal.minutes.inWholeSeconds },
                         durationSeconds = { minutesLeft.minutes.inWholeSeconds },
                         durationMinutes = { minutesLeft.minutes.inWholeMinutes },
+                        expiresAt = Instant.now().plusSeconds(minutesTotal.minutes.inWholeSeconds),
                         modifier = Modifier.padding(viewPadding),
                     )
                 }


### PR DESCRIPTION
Mirrors the change from trakt-web/pull/2381.

The expiresAt instant is
formatted as a locale-aware short time and displayed below the remaining
duration in the expanded check-in toast.
