### PR TITLE
feat: enable socials info for media summaries

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/TraktApplication.kt
+++ b/app/src/main/java/tv/trakt/trakt/TraktApplication.kt
@@ -78,6 +78,7 @@ import tv.trakt.trakt.core.summary.people.di.personDetailsModule
 import tv.trakt.trakt.core.summary.sentiment.di.sentimentModule
 import tv.trakt.trakt.core.summary.shows.di.showDetailsDataModule
 import tv.trakt.trakt.core.summary.shows.di.showDetailsModule
+import tv.trakt.trakt.core.summary.social.di.mediaSocialActivityModule
 import tv.trakt.trakt.core.sync.di.syncModule
 import tv.trakt.trakt.core.trivia.di.triviaModule
 import tv.trakt.trakt.core.userprofile.di.userProfileModule
@@ -161,6 +162,7 @@ internal class TraktApplication : Application() {
                 moviesDataModule,
                 movieDetailsModule,
                 movieDetailsDataModule,
+                mediaSocialActivityModule,
                 profileModule,
                 profileDataModule,
                 peopleDataModule,

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/social/ui/SocialUserView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/social/ui/SocialUserView.kt
@@ -34,6 +34,7 @@ internal fun SocialUserView(
     user: User,
     modifier: Modifier = Modifier,
     size: Dp = 56.dp,
+    showName: Boolean = true,
     onUserClick: () -> Unit = {},
 ) {
     Column(
@@ -82,15 +83,17 @@ internal fun SocialUserView(
             }
         }
 
-        Text(
-            text = user.displayName,
-            style = TraktTheme.typography.cardTitle,
-            color = TraktTheme.colors.textPrimary,
-            maxLines = 1,
-            textAlign = TextAlign.Center,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.width(size + 8.dp),
-        )
+        if (showName) {
+            Text(
+                text = user.displayName,
+                style = TraktTheme.typography.cardTitle,
+                color = TraktTheme.colors.textPrimary,
+                maxLines = 1,
+                textAlign = TextAlign.Center,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.width(size + 8.dp),
+            )
+        }
     }
 }
 
@@ -113,6 +116,7 @@ private fun Preview2() {
                 name = "John Dutton",
                 isVip = true,
             ),
+            showName = false,
         )
     }
 }

--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/EpisodeDetailsScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/EpisodeDetailsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
@@ -85,6 +86,8 @@ import tv.trakt.trakt.core.summary.episodes.features.info.EpisodeInfoSheet
 import tv.trakt.trakt.core.summary.episodes.features.related.EpisodeRelatedView
 import tv.trakt.trakt.core.summary.episodes.features.season.EpisodeSeasonView
 import tv.trakt.trakt.core.summary.episodes.features.streaming.EpisodeStreamingsView
+import tv.trakt.trakt.core.summary.social.MediaSocialActivitySheet
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 import tv.trakt.trakt.core.summary.ui.DetailsActions
 import tv.trakt.trakt.core.summary.ui.DetailsBackground
 import tv.trakt.trakt.core.summary.ui.header.DetailsHeader
@@ -124,6 +127,7 @@ internal fun EpisodeDetailsScreen(
     var dateSheet by remember { mutableStateOf(false) }
     var detailsSheet by remember { mutableStateOf<Pair<Show, Episode>?>(null) }
     var coverImageSheet by remember { mutableStateOf(false) }
+    var socialActivitySheet by remember { mutableStateOf<ImmutableList<MediaSocialActivity>?>(null) }
 
     DisposableEffect(Unit) {
         localRateVisibility.value = false
@@ -158,6 +162,11 @@ internal fun EpisodeDetailsScreen(
                 episode = state.episode,
                 context = context,
             )
+        },
+        onSocialActivityClick = {
+            state.episodeSocials?.let {
+                socialActivitySheet = it
+            }
         },
         onHistoryClick = {
             historySheet = it
@@ -276,6 +285,17 @@ internal fun EpisodeDetailsScreen(
         onDismiss = { detailsSheet = null },
     )
 
+    MediaSocialActivitySheet(
+        activity = socialActivitySheet,
+        mediaTitle = state.episode?.title ?: "",
+        onUserClick = {
+            onNavigateToUser(it)
+        },
+        onDismiss = {
+            socialActivitySheet = null
+        },
+    )
+
     CoverImageSheet(
         mediaId = when {
             coverImageSheet -> state.episode?.ids?.trakt
@@ -326,6 +346,7 @@ internal fun EpisodeDetailsContent(
     onEpisodeClick: ((Episode) -> Unit)? = null,
     onTrackClick: (() -> Unit)? = null,
     onShareClick: (() -> Unit)? = null,
+    onSocialActivityClick: (() -> Unit)? = null,
     onMoreClick: (() -> Unit)? = null,
     onMoreCommentsClick: ((CommentsFilter) -> Unit)? = null,
     onHistoryClick: ((HomeActivityItem.EpisodeItem) -> Unit)? = null,
@@ -408,6 +429,7 @@ internal fun EpisodeDetailsContent(
                         episode = state.episode,
                         show = state.show,
                         episodeTranslation = state.episodeTranslation,
+                        episodeSocials = state.episodeSocials,
                         ratings = state.episodeRatings,
                         creator = state.episodeCreator,
                         playsCount = state.episodeProgress?.plays ?: 0,
@@ -416,6 +438,7 @@ internal fun EpisodeDetailsContent(
                         onShowClick = onShowClick ?: {},
                         onBackClick = onBackClick ?: {},
                         onShareClick = onShareClick ?: {},
+                        onSocialActivityClick = onSocialActivityClick ?: {},
                         onInfoClick = onInfoClick ?: {},
                         modifier = Modifier
                             .align(Center)

--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/EpisodeDetailsState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/EpisodeDetailsState.kt
@@ -1,6 +1,7 @@
 package tv.trakt.trakt.core.summary.episodes
 
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
 import tv.trakt.trakt.common.core.translations.model.MediaTranslation
 import tv.trakt.trakt.common.helpers.LoadingState
 import tv.trakt.trakt.common.helpers.StringResource
@@ -11,6 +12,7 @@ import tv.trakt.trakt.common.model.Show
 import tv.trakt.trakt.common.model.TraktId
 import tv.trakt.trakt.common.model.User
 import tv.trakt.trakt.common.model.ratings.UserRating
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 
 @Immutable
 internal data class EpisodeDetailsState(
@@ -21,6 +23,7 @@ internal data class EpisodeDetailsState(
     val episodeProgress: ProgressState? = null,
     val episodeCreator: Person? = null,
     val episodeTranslation: MediaTranslation? = null,
+    val episodeSocials: ImmutableList<MediaSocialActivity>? = null,
     val navigateEpisode: Pair<TraktId, Episode>? = null,
     val loading: LoadingState = LoadingState.Idle,
     val loadingProgress: LoadingState = LoadingState.Idle,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/EpisodeDetailsViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/EpisodeDetailsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -54,12 +55,14 @@ import tv.trakt.trakt.core.summary.episodes.data.EpisodeDetailsUpdates
 import tv.trakt.trakt.core.summary.episodes.data.EpisodeDetailsUpdates.Source.PROGRESS
 import tv.trakt.trakt.core.summary.episodes.data.EpisodeDetailsUpdates.Source.SEASON
 import tv.trakt.trakt.core.summary.episodes.features.actors.usecases.GetEpisodeDirectorUseCase
+import tv.trakt.trakt.core.summary.episodes.features.socials.GetEpisodeSocialsUseCase
 import tv.trakt.trakt.core.summary.episodes.navigation.EpisodeDetailsDestination
 import tv.trakt.trakt.core.summary.episodes.usecases.GetEpisodeDetailsUseCase
 import tv.trakt.trakt.core.summary.episodes.usecases.GetEpisodeRatingsUseCase
 import tv.trakt.trakt.core.summary.shows.data.ShowDetailsUpdates
 import tv.trakt.trakt.core.summary.shows.data.ShowDetailsUpdates.Source
 import tv.trakt.trakt.core.summary.shows.usecases.GetShowDetailsUseCase
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 import tv.trakt.trakt.core.sync.usecases.UpdateEpisodeHistoryUseCase
 import tv.trakt.trakt.core.user.usecases.progress.LoadUserProgressUseCase
 import tv.trakt.trakt.core.user.usecases.ratings.LoadUserRatingsUseCase
@@ -74,6 +77,7 @@ internal class EpisodeDetailsViewModel(
     private val getEpisodeDetailsUseCase: GetEpisodeDetailsUseCase,
     private val getEpisodeDirectorUseCase: GetEpisodeDirectorUseCase,
     private val getEpisodeTranslationsUseCase: GetEpisodeTranslationsUseCase,
+    private val getEpisodeSocialsUseCase: GetEpisodeSocialsUseCase,
     private val getRatingsUseCase: GetEpisodeRatingsUseCase,
     private val loadProgressUseCase: LoadUserProgressUseCase,
     private val loadRatingUseCase: LoadUserRatingsUseCase,
@@ -104,6 +108,7 @@ internal class EpisodeDetailsViewModel(
     private val episodeProgressState = MutableStateFlow(initialState.episodeProgress)
     private val episodeCreatorState = MutableStateFlow(initialState.episodeCreator)
     private val episodeTranslationState = MutableStateFlow(initialState.episodeTranslation)
+    private val episodeSocialsState = MutableStateFlow(initialState.episodeSocials)
     private val navigateEpisode = MutableStateFlow(initialState.navigateEpisode)
     private val loadingState = MutableStateFlow(initialState.loading)
     private val loadingProgress = MutableStateFlow(initialState.loadingProgress)
@@ -202,6 +207,7 @@ internal class EpisodeDetailsViewModel(
 
                 loadTranslations()
                 loadRatings(episode)
+                loadSocials(episode)
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     errorState.update { error }
@@ -268,6 +274,27 @@ internal class EpisodeDetailsViewModel(
                 }
             } finally {
                 loadingProgress.update { Done }
+            }
+        }
+    }
+
+    private fun loadSocials(episode: Episode?) {
+        if (episode == null) {
+            return
+        }
+        viewModelScope.launch {
+            try {
+                episodeSocialsState.update {
+                    getEpisodeSocialsUseCase.getSocials(
+                        showId = showId,
+                        season = episode.season,
+                        episode = episode.number,
+                    )
+                }
+            } catch (error: Exception) {
+                error.rethrowCancellation {
+                    Timber.recordError(error)
+                }
             }
         }
     }
@@ -643,6 +670,7 @@ internal class EpisodeDetailsViewModel(
         episodeProgressState,
         episodeCreatorState,
         episodeTranslationState,
+        episodeSocialsState,
         loadingState,
         loadingProgress,
         infoState,
@@ -658,12 +686,13 @@ internal class EpisodeDetailsViewModel(
             episodeProgress = state[4] as EpisodeDetailsState.ProgressState?,
             episodeCreator = state[5] as Person?,
             episodeTranslation = state[6] as MediaTranslation?,
-            loading = state[7] as LoadingState,
-            loadingProgress = state[8] as LoadingState,
-            info = state[9] as StringResource?,
-            error = state[10] as Exception?,
-            user = state[11] as User?,
-            navigateEpisode = state[12] as Pair<TraktId, Episode>?,
+            episodeSocials = state[7] as ImmutableList<MediaSocialActivity>?,
+            loading = state[8] as LoadingState,
+            loadingProgress = state[9] as LoadingState,
+            info = state[10] as StringResource?,
+            error = state[11] as Exception?,
+            user = state[12] as User?,
+            navigateEpisode = state[13] as Pair<TraktId, Episode>?,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/di/EpisodeDetailsModule.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/di/EpisodeDetailsModule.kt
@@ -1,6 +1,7 @@
 package tv.trakt.trakt.core.summary.episodes.di
 
 import org.koin.android.ext.koin.androidApplication
+import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import tv.trakt.trakt.common.core.episodes.data.local.EpisodeLocalDataSource
@@ -25,6 +26,7 @@ import tv.trakt.trakt.core.summary.episodes.features.related.EpisodeRelatedViewM
 import tv.trakt.trakt.core.summary.episodes.features.related.usecases.GetEpisodeRelatedUseCase
 import tv.trakt.trakt.core.summary.episodes.features.season.EpisodeSeasonViewModel
 import tv.trakt.trakt.core.summary.episodes.features.season.usecases.GetEpisodeSeasonUseCase
+import tv.trakt.trakt.core.summary.episodes.features.socials.GetEpisodeSocialsUseCase
 import tv.trakt.trakt.core.summary.episodes.features.streaming.EpisodeStreamingsViewModel
 import tv.trakt.trakt.core.summary.episodes.features.streaming.usecases.GetEpisodeStreamingsUseCase
 import tv.trakt.trakt.core.summary.episodes.usecases.GetEpisodeDetailsUseCase
@@ -124,6 +126,8 @@ internal val episodeDetailsModule = module {
         )
     }
 
+    factoryOf(::GetEpisodeSocialsUseCase)
+
     viewModel {
         EpisodeDetailsViewModel(
             appContext = androidApplication(),
@@ -132,6 +136,7 @@ internal val episodeDetailsModule = module {
             getEpisodeDetailsUseCase = get(),
             getEpisodeDirectorUseCase = get(),
             getEpisodeTranslationsUseCase = get(),
+            getEpisodeSocialsUseCase = get(),
             getRatingsUseCase = get(),
             loadProgressUseCase = get(),
             loadRatingUseCase = get(),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/socials/GetEpisodeSocialsUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/socials/GetEpisodeSocialsUseCase.kt
@@ -1,0 +1,41 @@
+package tv.trakt.trakt.core.summary.episodes.features.socials
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import tv.trakt.trakt.common.auth.session.SessionManager
+import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
+import tv.trakt.trakt.common.model.MediaType.EPISODE
+import tv.trakt.trakt.common.model.TraktId
+import tv.trakt.trakt.common.model.pagination.Pagination
+import tv.trakt.trakt.common.networking.api.v3.V3Api
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+
+internal class GetEpisodeSocialsUseCase(
+    val remoteSource: V3Api,
+    private val sessionManager: SessionManager,
+) {
+    suspend fun getSocials(
+        showId: TraktId,
+        season: Int,
+        episode: Int,
+    ): ImmutableList<MediaSocialActivity> {
+        if (!sessionManager.isAuthenticated()) {
+            return EmptyImmutableList
+        }
+
+        val remoteData = remoteSource.getEpisodeSocialActivity(
+            showId = showId,
+            season = season,
+            episode = episode,
+            pagination = Pagination(1, 250),
+        )
+        if (remoteData.isNullOrEmpty()) {
+            return EmptyImmutableList
+        }
+
+        return remoteData
+            .map { MediaSocialActivity.fromDto(it, EPISODE) }
+            .sortedByDescending { it.lastActivityAt }
+            .toImmutableList()
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/socials/GetEpisodeSocialsUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/episodes/features/socials/GetEpisodeSocialsUseCase.kt
@@ -11,7 +11,7 @@ import tv.trakt.trakt.common.networking.api.v3.V3Api
 import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 
 internal class GetEpisodeSocialsUseCase(
-    val remoteSource: V3Api,
+    private val remoteSource: V3Api,
     private val sessionManager: SessionManager,
 ) {
     suspend fun getSocials(

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/MovieDetailsScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/MovieDetailsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
@@ -90,6 +91,8 @@ import tv.trakt.trakt.core.summary.movies.features.related.MovieRelatedView
 import tv.trakt.trakt.core.summary.movies.features.sentiment.MovieSentimentView
 import tv.trakt.trakt.core.summary.movies.features.streaming.MovieStreamingsView
 import tv.trakt.trakt.core.summary.movies.features.trivia.MovieTriviaView
+import tv.trakt.trakt.core.summary.social.MediaSocialActivitySheet
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 import tv.trakt.trakt.core.summary.ui.DetailsActions
 import tv.trakt.trakt.core.summary.ui.DetailsBackground
 import tv.trakt.trakt.core.summary.ui.header.DetailsHeader
@@ -135,6 +138,7 @@ internal fun MovieDetailsScreen(
     var dateSheet by remember { mutableStateOf(false) }
     var shareSheet by remember { mutableStateOf(false) }
     var coverImageSheet by remember { mutableStateOf<Movie?>(null) }
+    var socialActivitySheet by remember { mutableStateOf<ImmutableList<MediaSocialActivity>?>(null) }
 
     DisposableEffect(Unit) {
         localRateVisibility.value = false
@@ -175,6 +179,11 @@ internal fun MovieDetailsScreen(
         },
         onShareImageClick = {
             state.movie?.let { shareSheet = true }
+        },
+        onSocialActivityClick = {
+            state.movieSocials?.let {
+                socialActivitySheet = it
+            }
         },
         onTrailerClick = {
             state.movie?.trailer?.let { url ->
@@ -358,6 +367,17 @@ internal fun MovieDetailsScreen(
         onDismiss = { shareSheet = false },
     )
 
+    MediaSocialActivitySheet(
+        activity = socialActivitySheet,
+        mediaTitle = state.movie?.title ?: "",
+        onUserClick = {
+            onNavigateToUser?.invoke(it)
+        },
+        onDismiss = {
+            socialActivitySheet = null
+        },
+    )
+
     LaunchedEffect(state.info) {
         if (state.info == null) {
             return@LaunchedEffect
@@ -384,6 +404,7 @@ internal fun MovieDetailsContent(
     onTrackClick: (() -> Unit)? = null,
     onShareClick: (() -> Unit)? = null,
     onShareImageClick: (() -> Unit)? = null,
+    onSocialActivityClick: (() -> Unit)? = null,
     onInfoClick: (() -> Unit)? = null,
     onTrailerClick: (() -> Unit)? = null,
     onExtraClick: ((ExtraVideo) -> Unit)? = null,
@@ -469,6 +490,7 @@ internal fun MovieDetailsContent(
                     DetailsHeader(
                         movie = movie,
                         movieTranslation = state.movieTranslation,
+                        movieSocials = state.movieSocials,
                         ratings = state.movieRatings,
                         creator = state.movieCreator,
                         creditsCount = when {
@@ -482,6 +504,7 @@ internal fun MovieDetailsContent(
                         onBackClick = onBackClick ?: {},
                         onShareClick = onShareClick ?: {},
                         onShareImageClick = onShareImageClick ?: {},
+                        onSocialActivityClick = onSocialActivityClick ?: {},
                         onInfoClick = onInfoClick ?: {},
                         modifier = Modifier
                             .align(Alignment.Center)

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/MovieDetailsState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/MovieDetailsState.kt
@@ -1,6 +1,7 @@
 package tv.trakt.trakt.core.summary.movies
 
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
 import tv.trakt.trakt.common.core.translations.model.MediaTranslation
 import tv.trakt.trakt.common.helpers.LoadingState
 import tv.trakt.trakt.common.helpers.StringResource
@@ -9,6 +10,7 @@ import tv.trakt.trakt.common.model.Movie
 import tv.trakt.trakt.common.model.Person
 import tv.trakt.trakt.common.model.User
 import tv.trakt.trakt.common.model.ratings.UserRating
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 
 @Immutable
 internal data class MovieDetailsState(
@@ -18,6 +20,7 @@ internal data class MovieDetailsState(
     val movieProgress: ProgressState? = null,
     val movieCreator: Person? = null,
     val movieTranslation: MediaTranslation? = null,
+    val movieSocials: ImmutableList<MediaSocialActivity>? = null,
     val loading: LoadingState = LoadingState.Idle,
     val loadingProgress: LoadingState = LoadingState.Idle,
     val loadingLists: LoadingState = LoadingState.Idle,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/MovieDetailsViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/MovieDetailsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -64,9 +65,11 @@ import tv.trakt.trakt.core.ratings.data.work.PostRatingWorker
 import tv.trakt.trakt.core.summary.movies.MovieDetailsState.UserRatingsState
 import tv.trakt.trakt.core.summary.movies.data.MovieDetailsUpdates
 import tv.trakt.trakt.core.summary.movies.features.actors.usecases.GetMovieDirectorUseCase
+import tv.trakt.trakt.core.summary.movies.features.socials.GetMovieSocialsUseCase
 import tv.trakt.trakt.core.summary.movies.navigation.MovieDetailsDestination
 import tv.trakt.trakt.core.summary.movies.usecases.GetMovieDetailsUseCase
 import tv.trakt.trakt.core.summary.movies.usecases.GetMovieRatingsUseCase
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 import tv.trakt.trakt.core.sync.usecases.UpdateMovieFavoritesUseCase
 import tv.trakt.trakt.core.sync.usecases.UpdateMovieHistoryUseCase
 import tv.trakt.trakt.core.sync.usecases.UpdateMovieWatchlistUseCase
@@ -82,6 +85,7 @@ import tv.trakt.trakt.core.user.usecases.progress.LoadUserProgressUseCase
 import tv.trakt.trakt.core.user.usecases.ratings.LoadUserRatingsUseCase
 import tv.trakt.trakt.resources.R
 import java.util.Locale
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class MovieDetailsViewModel(
     savedStateHandle: SavedStateHandle,
@@ -90,6 +94,7 @@ internal class MovieDetailsViewModel(
     private val getExternalRatingsUseCase: GetMovieRatingsUseCase,
     private val getMovieDirectorUseCase: GetMovieDirectorUseCase,
     private val getMovieTranslationsUseCase: GetMovieTranslationsUseCase,
+    private val getMovieSocialsUseCase: GetMovieSocialsUseCase,
     private val loadProgressUseCase: LoadUserProgressUseCase,
     private val loadWatchlistUseCase: LoadUserWatchlistUseCase,
     private val loadListsUseCase: LoadUserListsUseCase,
@@ -124,6 +129,7 @@ internal class MovieDetailsViewModel(
     private val movieCreatorState = MutableStateFlow(initialState.movieCreator)
     private val movieProgressState = MutableStateFlow(initialState.movieProgress)
     private val movieTranslationState = MutableStateFlow(initialState.movieTranslation)
+    private val movieSocialsState = MutableStateFlow(initialState.movieSocials)
     private val loadingState = MutableStateFlow(initialState.loading)
     private val loadingProgress = MutableStateFlow(initialState.loadingProgress)
     private val loadingLists = MutableStateFlow(initialState.loadingLists)
@@ -151,7 +157,7 @@ internal class MovieDetailsViewModel(
     private fun observeCheckIn() {
         checkInUpdates.observeUpdates()
             .distinctUntilChanged()
-            .debounce(200)
+            .debounce(200.milliseconds)
             .filterNot { it.first == MovieDetails }
             .onEach {
                 loadUserProgressData(force = true)
@@ -187,6 +193,7 @@ internal class MovieDetailsViewModel(
 
                 loadTranslations()
                 loadRatings(movie)
+                loadSocials()
                 loadCreator()
             } catch (error: Exception) {
                 error.rethrowCancellation {
@@ -208,6 +215,20 @@ internal class MovieDetailsViewModel(
                         movieId = movieId,
                         locale = locale,
                     )
+                }
+            } catch (error: Exception) {
+                error.rethrowCancellation {
+                    Timber.recordError(error)
+                }
+            }
+        }
+    }
+
+    private fun loadSocials() {
+        viewModelScope.launch {
+            try {
+                movieSocialsState.update {
+                    getMovieSocialsUseCase.getSocials(movieId)
                 }
             } catch (error: Exception) {
                 error.rethrowCancellation {
@@ -807,7 +828,7 @@ internal class MovieDetailsViewModel(
             try {
                 loadingFavorite.update { Loading }
 
-                delay(300) // Small delay to allow UI to settle.
+                delay(300.milliseconds) // Small delay to allow UI to settle.
                 updateMovieFavoritesUseCase.addToFavorites(movieId)
                 userFavoritesLocalSource.addMovies(
                     movies = listOf(
@@ -861,7 +882,7 @@ internal class MovieDetailsViewModel(
             try {
                 loadingFavorite.update { Loading }
 
-                delay(300) // Small delay to allow UI to settle.
+                delay(300.milliseconds) // Small delay to allow UI to settle.
                 updateMovieFavoritesUseCase.removeFromFavorites(movieId)
                 userFavoritesLocalSource.removeMovies(setOf(movieId))
                 favoritesUpdates.notifyUpdate(DETAILS)
@@ -978,6 +999,7 @@ internal class MovieDetailsViewModel(
         movieProgressState,
         movieUserRatingsState,
         movieTranslationState,
+        movieSocialsState,
         loadingState,
         loadingProgress,
         loadingLists,
@@ -993,13 +1015,14 @@ internal class MovieDetailsViewModel(
             movieProgress = state[3] as MovieDetailsState.ProgressState?,
             movieUserRating = state[4] as UserRatingsState?,
             movieTranslation = state[5] as MediaTranslation?,
-            loading = state[6] as LoadingState,
-            loadingProgress = state[7] as LoadingState,
-            loadingLists = state[8] as LoadingState,
-            loadingFavorite = state[9] as LoadingState,
-            info = state[10] as StringResource?,
-            error = state[11] as Exception?,
-            user = state[12] as User?,
+            movieSocials = state[6] as ImmutableList<MediaSocialActivity>?,
+            loading = state[7] as LoadingState,
+            loadingProgress = state[8] as LoadingState,
+            loadingLists = state[9] as LoadingState,
+            loadingFavorite = state[10] as LoadingState,
+            info = state[11] as StringResource?,
+            error = state[12] as Exception?,
+            user = state[13] as User?,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/di/MovieDetailsModule.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/di/MovieDetailsModule.kt
@@ -1,6 +1,7 @@
 package tv.trakt.trakt.core.summary.movies.di
 
 import org.koin.android.ext.koin.androidApplication
+import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import tv.trakt.trakt.common.core.movies.data.local.MovieLocalDataSource
@@ -30,6 +31,7 @@ import tv.trakt.trakt.core.summary.movies.features.related.MovieRelatedViewModel
 import tv.trakt.trakt.core.summary.movies.features.related.usecases.GetMovieRelatedUseCase
 import tv.trakt.trakt.core.summary.movies.features.sentiment.MovieSentimentViewModel
 import tv.trakt.trakt.core.summary.movies.features.sentiment.usecases.GetMovieSentimentUseCase
+import tv.trakt.trakt.core.summary.movies.features.socials.GetMovieSocialsUseCase
 import tv.trakt.trakt.core.summary.movies.features.streaming.MovieStreamingsViewModel
 import tv.trakt.trakt.core.summary.movies.features.streaming.usecases.GetMovieStreamingsUseCase
 import tv.trakt.trakt.core.summary.movies.features.trivia.MovieTriviaViewModel
@@ -155,6 +157,8 @@ internal val movieDetailsModule = module {
         )
     }
 
+    factoryOf(::GetMovieSocialsUseCase)
+
     viewModel {
         MovieDetailsViewModel(
             appContext = androidApplication(),
@@ -163,6 +167,7 @@ internal val movieDetailsModule = module {
             getExternalRatingsUseCase = get(),
             getMovieDirectorUseCase = get(),
             getMovieTranslationsUseCase = get(),
+            getMovieSocialsUseCase = get(),
             loadProgressUseCase = get(),
             loadWatchlistUseCase = get(),
             loadListsUseCase = get(),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/socials/GetMovieSocialsUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/socials/GetMovieSocialsUseCase.kt
@@ -1,0 +1,32 @@
+package tv.trakt.trakt.core.summary.movies.features.socials
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import tv.trakt.trakt.common.auth.session.SessionManager
+import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
+import tv.trakt.trakt.common.model.MediaType.MOVIE
+import tv.trakt.trakt.common.model.TraktId
+import tv.trakt.trakt.common.model.pagination.Pagination
+import tv.trakt.trakt.common.networking.api.v3.V3Api
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+
+internal class GetMovieSocialsUseCase(
+    private val remoteSource: V3Api,
+    private val sessionManager: SessionManager,
+) {
+    suspend fun getSocials(movieId: TraktId): ImmutableList<MediaSocialActivity> {
+        if (!sessionManager.isAuthenticated()) {
+            return EmptyImmutableList
+        }
+
+        val remoteData = remoteSource.getMovieSocialActivity(movieId, Pagination(1, 250))
+        if (remoteData.isNullOrEmpty()) {
+            return EmptyImmutableList
+        }
+
+        return remoteData
+            .map { MediaSocialActivity.fromDto(it, MOVIE) }
+            .sortedByDescending { it.lastActivityAt }
+            .toImmutableList()
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/trivia/MovieTriviaViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/movies/features/trivia/MovieTriviaViewModel.kt
@@ -30,6 +30,7 @@ import tv.trakt.trakt.common.model.trivia.TriviaFact
 import tv.trakt.trakt.core.summary.movies.features.trivia.usecases.GetMovieTriviaUseCase
 import tv.trakt.trakt.helpers.collapsing.CollapsingManager
 import tv.trakt.trakt.helpers.collapsing.model.CollapsingKey
+import kotlin.time.Duration.Companion.milliseconds
 
 private val collapsingKey = CollapsingKey.MOVIE_TRIVIA
 
@@ -59,7 +60,7 @@ internal class MovieTriviaViewModel(
     private fun observeUser() {
         sessionManager.observeProfile()
             .distinctUntilChanged()
-            .debounce(200)
+            .debounce(200.milliseconds)
             .filter {
                 // Only update if VIP status has changed, as trivia may be VIP locked.
                 userState.value?.isAnyVip != it?.isAnyVip

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/ShowDetailsScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/ShowDetailsScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
@@ -97,6 +98,8 @@ import tv.trakt.trakt.core.summary.shows.features.seasons.ShowSeasonsView
 import tv.trakt.trakt.core.summary.shows.features.sentiment.ShowSentimentView
 import tv.trakt.trakt.core.summary.shows.features.streaming.ShowStreamingsView
 import tv.trakt.trakt.core.summary.shows.features.trivia.ShowTriviaView
+import tv.trakt.trakt.core.summary.social.MediaSocialActivitySheet
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 import tv.trakt.trakt.core.summary.ui.DetailsActions
 import tv.trakt.trakt.core.summary.ui.DetailsBackground
 import tv.trakt.trakt.core.summary.ui.header.DetailsHeader
@@ -146,6 +149,7 @@ internal fun ShowDetailsScreen(
     var dateSheet by remember { mutableStateOf(false) }
     var shareSheet by remember { mutableStateOf(false) }
     var coverImageSheet by remember { mutableStateOf<Show?>(null) }
+    var socialActivitySheet by remember { mutableStateOf<ImmutableList<MediaSocialActivity>?>(null) }
 
     DisposableEffect(Unit) {
         localRateVisibility.value = false
@@ -191,6 +195,11 @@ internal fun ShowDetailsScreen(
         },
         onShareImageClick = {
             state.show?.let { shareSheet = true }
+        },
+        onSocialActivityClick = {
+            state.showSocials?.let {
+                socialActivitySheet = it
+            }
         },
         onTrailerClick = {
             state.show?.trailer?.let { url -> onTrailerClick(url) }
@@ -401,6 +410,17 @@ internal fun ShowDetailsScreen(
         onDismiss = { shareSheet = false },
     )
 
+    MediaSocialActivitySheet(
+        activity = socialActivitySheet,
+        mediaTitle = state.show?.title ?: "",
+        onUserClick = {
+            onNavigateToUser?.invoke(it)
+        },
+        onDismiss = {
+            socialActivitySheet = null
+        },
+    )
+
     LaunchedEffect(state.navigateEpisode) {
         state.navigateEpisode?.let {
             onEpisodeClick(it.first, it.second)
@@ -435,6 +455,7 @@ internal fun ShowDetailsContent(
     onTrackClick: (() -> Unit)? = null,
     onShareClick: (() -> Unit)? = null,
     onShareImageClick: (() -> Unit)? = null,
+    onSocialActivityClick: (() -> Unit)? = null,
     onInfoClick: (() -> Unit)? = null,
     onTrailerClick: (() -> Unit)? = null,
     onExtraClick: ((ExtraVideo) -> Unit)? = null,
@@ -521,6 +542,7 @@ internal fun ShowDetailsContent(
                     DetailsHeader(
                         show = show,
                         showTranslation = state.showTranslation,
+                        showSocials = state.showSocials,
                         ratings = state.showRatings,
                         creator = state.showCreator,
                         airedCount = state.showProgress?.aired ?: 0,
@@ -531,6 +553,7 @@ internal fun ShowDetailsContent(
                         onBackClick = onBackClick ?: {},
                         onShareClick = onShareClick ?: {},
                         onShareImageClick = onShareImageClick ?: {},
+                        onSocialActivityClick = onSocialActivityClick ?: {},
                         onInfoClick = onInfoClick ?: {},
                         modifier = Modifier
                             .align(Alignment.Center)

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/ShowDetailsState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/ShowDetailsState.kt
@@ -1,6 +1,7 @@
 package tv.trakt.trakt.core.summary.shows
 
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
 import tv.trakt.trakt.common.core.translations.model.MediaTranslation
 import tv.trakt.trakt.common.helpers.LoadingState
 import tv.trakt.trakt.common.helpers.StringResource
@@ -11,6 +12,7 @@ import tv.trakt.trakt.common.model.Show
 import tv.trakt.trakt.common.model.TraktId
 import tv.trakt.trakt.common.model.User
 import tv.trakt.trakt.common.model.ratings.UserRating
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 
 @Immutable
 internal data class ShowDetailsState(
@@ -20,6 +22,7 @@ internal data class ShowDetailsState(
     val showProgress: ProgressState? = null,
     val showCreator: Person? = null,
     val showTranslation: MediaTranslation? = null,
+    val showSocials: ImmutableList<MediaSocialActivity>? = null,
     val navigateEpisode: Pair<TraktId, Episode>? = null,
     val loading: LoadingState = LoadingState.Idle,
     val loadingProgress: LoadingState = LoadingState.Idle,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/ShowDetailsViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/ShowDetailsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -61,9 +62,11 @@ import tv.trakt.trakt.core.summary.shows.ShowDetailsState.UserRatingsState
 import tv.trakt.trakt.core.summary.shows.data.ShowDetailsUpdates
 import tv.trakt.trakt.core.summary.shows.data.ShowDetailsUpdates.Source
 import tv.trakt.trakt.core.summary.shows.features.actors.usecases.GetShowCreatorUseCase
+import tv.trakt.trakt.core.summary.shows.features.socials.GetShowSocialsUseCase
 import tv.trakt.trakt.core.summary.shows.navigation.ShowDetailsDestination
 import tv.trakt.trakt.core.summary.shows.usecases.GetShowDetailsUseCase
 import tv.trakt.trakt.core.summary.shows.usecases.GetShowRatingsUseCase
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 import tv.trakt.trakt.core.sync.usecases.UpdateEpisodeHistoryUseCase
 import tv.trakt.trakt.core.sync.usecases.UpdateShowFavoritesUseCase
 import tv.trakt.trakt.core.sync.usecases.UpdateShowHistoryUseCase
@@ -89,6 +92,7 @@ internal class ShowDetailsViewModel(
     private val getExternalRatingsUseCase: GetShowRatingsUseCase,
     private val getShowCreatorUseCase: GetShowCreatorUseCase,
     private val getShowTranslationsUseCase: GetShowTranslationsUseCase,
+    private val getShowSocialsUseCase: GetShowSocialsUseCase,
     private val loadProgressUseCase: LoadUserProgressUseCase,
     private val loadWatchlistUseCase: LoadUserWatchlistUseCase,
     private val loadListsUseCase: LoadUserListsUseCase,
@@ -123,6 +127,7 @@ internal class ShowDetailsViewModel(
     private val showCreatorState = MutableStateFlow(initialState.showCreator)
     private val showProgressState = MutableStateFlow(initialState.showProgress)
     private val showTranslationState = MutableStateFlow(initialState.showTranslation)
+    private val showSocialsState = MutableStateFlow(initialState.showSocials)
     private val navigateEpisode = MutableStateFlow(initialState.navigateEpisode)
     private val loadingState = MutableStateFlow(initialState.loading)
     private val loadingProgress = MutableStateFlow(initialState.loadingProgress)
@@ -186,6 +191,7 @@ internal class ShowDetailsViewModel(
 
                 loadTranslations()
                 loadRatings(show)
+                loadSocials()
                 loadCreator()
             } catch (error: Exception) {
                 error.rethrowCancellation {
@@ -310,6 +316,20 @@ internal class ShowDetailsViewModel(
                         showId = showId,
                         locale = locale,
                     )
+                }
+            } catch (error: Exception) {
+                error.rethrowCancellation {
+                    Timber.recordError(error)
+                }
+            }
+        }
+    }
+
+    private fun loadSocials() {
+        viewModelScope.launch {
+            try {
+                showSocialsState.update {
+                    getShowSocialsUseCase.getSocials(showId)
                 }
             } catch (error: Exception) {
                 error.rethrowCancellation {
@@ -955,6 +975,7 @@ internal class ShowDetailsViewModel(
         showCreatorState,
         showProgressState,
         showTranslationState,
+        showSocialsState,
         navigateEpisode,
         loadingState,
         loadingProgress,
@@ -971,14 +992,15 @@ internal class ShowDetailsViewModel(
             showCreator = state[3] as Person?,
             showProgress = state[4] as ShowDetailsState.ProgressState?,
             showTranslation = state[5] as MediaTranslation?,
-            navigateEpisode = state[6] as Pair<TraktId, Episode>?,
-            loading = state[7] as LoadingState,
-            loadingProgress = state[8] as LoadingState,
-            loadingLists = state[9] as LoadingState,
-            loadingFavorite = state[10] as LoadingState,
-            info = state[11] as StringResource?,
-            error = state[12] as Exception?,
-            user = state[13] as User?,
+            showSocials = state[6] as ImmutableList<MediaSocialActivity>?,
+            navigateEpisode = state[7] as Pair<TraktId, Episode>?,
+            loading = state[8] as LoadingState,
+            loadingProgress = state[9] as LoadingState,
+            loadingLists = state[10] as LoadingState,
+            loadingFavorite = state[11] as LoadingState,
+            info = state[12] as StringResource?,
+            error = state[13] as Exception?,
+            user = state[14] as User?,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/di/ShowDetailsModule.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/di/ShowDetailsModule.kt
@@ -1,6 +1,7 @@
 package tv.trakt.trakt.core.summary.shows.di
 
 import org.koin.android.ext.koin.androidApplication
+import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import tv.trakt.trakt.common.core.shows.data.local.ShowLocalDataSource
@@ -33,6 +34,7 @@ import tv.trakt.trakt.core.summary.shows.features.seasons.all.AllShowSeasonsView
 import tv.trakt.trakt.core.summary.shows.features.seasons.usecases.GetShowSeasonsUseCase
 import tv.trakt.trakt.core.summary.shows.features.sentiment.ShowSentimentViewModel
 import tv.trakt.trakt.core.summary.shows.features.sentiment.usecases.GetShowSentimentUseCase
+import tv.trakt.trakt.core.summary.shows.features.socials.GetShowSocialsUseCase
 import tv.trakt.trakt.core.summary.shows.features.streaming.ShowStreamingsViewModel
 import tv.trakt.trakt.core.summary.shows.features.streaming.usecases.GetShowStreamingsUseCase
 import tv.trakt.trakt.core.summary.shows.features.trivia.ShowTriviaViewModel
@@ -166,6 +168,8 @@ internal val showDetailsModule = module {
         )
     }
 
+    factoryOf(::GetShowSocialsUseCase)
+
     viewModel {
         ShowDetailsViewModel(
             appContext = androidApplication(),
@@ -174,6 +178,7 @@ internal val showDetailsModule = module {
             getExternalRatingsUseCase = get(),
             getShowCreatorUseCase = get(),
             getShowTranslationsUseCase = get(),
+            getShowSocialsUseCase = get(),
             loadProgressUseCase = get(),
             loadWatchlistUseCase = get(),
             loadListsUseCase = get(),

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/socials/GetShowSocialsUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/socials/GetShowSocialsUseCase.kt
@@ -11,7 +11,7 @@ import tv.trakt.trakt.common.networking.api.v3.V3Api
 import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
 
 internal class GetShowSocialsUseCase(
-    val remoteSource: V3Api,
+    private val remoteSource: V3Api,
     private val sessionManager: SessionManager,
 ) {
     suspend fun getSocials(showId: TraktId): ImmutableList<MediaSocialActivity> {

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/socials/GetShowSocialsUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/socials/GetShowSocialsUseCase.kt
@@ -1,0 +1,32 @@
+package tv.trakt.trakt.core.summary.shows.features.socials
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import tv.trakt.trakt.common.auth.session.SessionManager
+import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
+import tv.trakt.trakt.common.model.MediaType.SHOW
+import tv.trakt.trakt.common.model.TraktId
+import tv.trakt.trakt.common.model.pagination.Pagination
+import tv.trakt.trakt.common.networking.api.v3.V3Api
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+
+internal class GetShowSocialsUseCase(
+    val remoteSource: V3Api,
+    private val sessionManager: SessionManager,
+) {
+    suspend fun getSocials(showId: TraktId): ImmutableList<MediaSocialActivity> {
+        if (!sessionManager.isAuthenticated()) {
+            return EmptyImmutableList
+        }
+
+        val remoteData = remoteSource.getShowSocialActivity(showId, Pagination(1, 250))
+        if (remoteData.isNullOrEmpty()) {
+            return EmptyImmutableList
+        }
+
+        return remoteData
+            .map { MediaSocialActivity.fromDto(it, SHOW) }
+            .sortedByDescending { it.lastActivityAt }
+            .toImmutableList()
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivitySheet.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivitySheet.kt
@@ -31,6 +31,7 @@ internal fun MediaSocialActivitySheet(
     onDismiss: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
+    val viewModelKey = remember(activity) { nextInt().toString() }
 
     if (activity != null) {
         TraktBottomSheet(
@@ -39,7 +40,7 @@ internal fun MediaSocialActivitySheet(
         ) {
             MediaSocialActivityView(
                 viewModel = koinViewModel(
-                    key = nextInt().toString(),
+                    key = viewModelKey,
                     parameters = { parametersOf(activity) },
                 ),
                 mediaTitle = mediaTitle,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivitySheet.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivitySheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivitySheet.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivitySheet.kt
@@ -1,0 +1,74 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package tv.trakt.trakt.core.summary.social
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+import tv.trakt.trakt.common.model.User
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+import tv.trakt.trakt.ui.components.TraktBottomSheet
+import kotlin.random.Random.Default.nextInt
+
+@Composable
+internal fun MediaSocialActivitySheet(
+    state: SheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+    ),
+    activity: ImmutableList<MediaSocialActivity>?,
+    mediaTitle: String,
+    onUserClick: (user: User) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+
+    if (activity != null) {
+        TraktBottomSheet(
+            sheetState = state,
+            onDismiss = onDismiss,
+        ) {
+            MediaSocialActivityView(
+                viewModel = koinViewModel(
+                    key = nextInt().toString(),
+                    parameters = { parametersOf(activity) },
+                ),
+                mediaTitle = mediaTitle,
+                onUserClick = {
+                    scope.dismissWithAction(
+                        sheet = state,
+                        action = { onUserClick(it) },
+                        onDismiss = onDismiss,
+                    )
+                },
+                modifier = Modifier
+                    .padding(bottom = 24.dp)
+                    .padding(horizontal = 24.dp),
+            )
+        }
+    }
+}
+
+private fun CoroutineScope.dismissWithAction(
+    sheet: SheetState,
+    action: () -> Unit = {},
+    onDismiss: () -> Unit,
+) {
+    launch {
+        sheet.hide()
+    }.invokeOnCompletion {
+        if (!sheet.isVisible) {
+            action()
+            onDismiss()
+        }
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityState.kt
@@ -1,0 +1,10 @@
+package tv.trakt.trakt.core.summary.social
+
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+
+@Immutable
+internal data class MediaSocialActivityState(
+    val activity: ImmutableList<MediaSocialActivity>? = null,
+)

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityView.kt
@@ -66,7 +66,7 @@ private fun MediaSocialActivityContent(
     onUserClick: (user: User) -> Unit = {},
 ) {
     LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
         contentPadding = PaddingValues(bottom = 12.dp),
         modifier = modifier.fillMaxWidth(),
     ) {

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityView.kt
@@ -1,0 +1,150 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package tv.trakt.trakt.core.summary.social
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.ColorImage
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import kotlinx.collections.immutable.persistentListOf
+import tv.trakt.trakt.common.helpers.extensions.DevicePreview
+import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
+import tv.trakt.trakt.common.helpers.preview.PreviewData
+import tv.trakt.trakt.common.model.Ids
+import tv.trakt.trakt.common.model.ImdbId
+import tv.trakt.trakt.common.model.MediaType
+import tv.trakt.trakt.common.model.SlugId
+import tv.trakt.trakt.common.model.TmdbId
+import tv.trakt.trakt.common.model.TraktId
+import tv.trakt.trakt.common.model.User
+import tv.trakt.trakt.common.model.toTraktId
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+import tv.trakt.trakt.core.summary.social.ui.MediaSocialItemCard
+import tv.trakt.trakt.resources.R
+import tv.trakt.trakt.ui.components.TraktHeader
+import tv.trakt.trakt.ui.theme.TraktTheme
+import kotlin.time.Duration.Companion.days
+
+@Composable
+internal fun MediaSocialActivityView(
+    viewModel: MediaSocialActivityViewModel,
+    mediaTitle: String,
+    onUserClick: (user: User) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    MediaSocialActivityContent(
+        state = state,
+        mediaTitle = mediaTitle,
+        onUserClick = onUserClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun MediaSocialActivityContent(
+    state: MediaSocialActivityState,
+    mediaTitle: String,
+    modifier: Modifier = Modifier,
+    onUserClick: (user: User) -> Unit = {},
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(bottom = 12.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        item(key = "header") {
+            TraktHeader(
+                title = stringResource(R.string.list_title_social_activity),
+                subtitle = mediaTitle,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
+
+        items(
+            items = state.activity.orEmpty(),
+            key = { it.user.ids.trakt.value },
+        ) { item ->
+            MediaSocialItemCard(
+                item = item,
+                containerColor = TraktTheme.colors.dialogOnContainer,
+                shadow = 1.dp,
+                onUserClick = { onUserClick(item.user) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalCoilApi::class)
+@DevicePreview
+@Composable
+private fun Preview() {
+    TraktTheme {
+        val previewHandler = AsyncImagePreviewHandler {
+            ColorImage(Color.Blue.toArgb())
+        }
+        CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
+            val item = MediaSocialActivity(
+                type = MediaType.MOVIE,
+                user = PreviewData.user1,
+                watched = MediaSocialActivity.Watched(
+                    lastWatchedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                    lastUpdatedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                    plays = 3,
+                    rated = MediaSocialActivity.Watched.Rated(
+                        rating = 8,
+                        ratedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                    ),
+                    commented = MediaSocialActivity.Watched.Commented(
+                        id = 1.toTraktId(),
+                        comment = "Sample comment by someone",
+                        spoiler = false,
+                        review = false,
+                        createdAt = nowUtcInstant(),
+                        updatedAt = nowUtcInstant(),
+                    ),
+                ),
+                watchlisted = MediaSocialActivity.Watchlisted(
+                    listedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                ),
+            )
+
+            MediaSocialActivityContent(
+                state = MediaSocialActivityState(
+                    activity = persistentListOf(
+                        item,
+                        item.copy(
+                            user = PreviewData.user1.copy(
+                                ids = Ids(
+                                    trakt = TraktId(2),
+                                    slug = SlugId("john-doe"),
+                                    imdb = ImdbId("tt1234567"),
+                                    tmdb = TmdbId(67890),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                mediaTitle = "The Movie Title",
+            )
+        }
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/MediaSocialActivityViewModel.kt
@@ -1,0 +1,24 @@
+package tv.trakt.trakt.core.summary.social
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+
+internal class MediaSocialActivityViewModel(
+    activity: ImmutableList<MediaSocialActivity>,
+) : ViewModel() {
+    private val activityState = MutableStateFlow(activity)
+
+    val state = activityState
+        .map { MediaSocialActivityState(activity = it) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = MediaSocialActivityState(activity = activity),
+        )
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/di/MediaSocialActivityModule.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/di/MediaSocialActivityModule.kt
@@ -1,0 +1,15 @@
+package tv.trakt.trakt.core.summary.social.di
+
+import kotlinx.collections.immutable.ImmutableList
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+import tv.trakt.trakt.core.summary.social.MediaSocialActivityViewModel
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+
+internal val mediaSocialActivityModule = module {
+    viewModel { (activity: ImmutableList<MediaSocialActivity>) ->
+        MediaSocialActivityViewModel(
+            activity = activity,
+        )
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/model/MediaSocialActivity.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/model/MediaSocialActivity.kt
@@ -1,0 +1,98 @@
+package tv.trakt.trakt.core.summary.social.model
+
+import androidx.compose.runtime.Immutable
+import tv.trakt.trakt.common.helpers.extensions.toInstant
+import tv.trakt.trakt.common.model.MediaType
+import tv.trakt.trakt.common.model.TraktId
+import tv.trakt.trakt.common.model.User
+import tv.trakt.trakt.common.model.fromDto
+import tv.trakt.trakt.common.model.toTraktId
+import tv.trakt.trakt.common.networking.api.v3.model.V3MediaSocialResponse
+import java.time.Instant
+
+@Immutable
+internal data class MediaSocialActivity(
+    val type: MediaType,
+    val user: User,
+    val watched: Watched?,
+    val watchlisted: Watchlisted?,
+) {
+    val lastActivityAt: Instant
+        get() {
+            val watchedAt = watched?.lastWatchedAt ?: Instant.MIN
+            val watchlistedAt = watchlisted?.listedAt ?: Instant.MIN
+            val ratedAt = watched?.rated?.ratedAt ?: Instant.MIN
+            val commentedAt = watched?.commented?.createdAt ?: Instant.MIN
+            return maxOf(watchedAt, watchlistedAt, ratedAt, commentedAt)
+        }
+
+    @Immutable
+    data class Watched(
+        val lastWatchedAt: Instant,
+        val lastUpdatedAt: Instant?,
+        val plays: Int,
+        val rated: Rated?,
+        val commented: Commented?,
+    ) {
+        @Immutable
+        data class Rated(
+            val rating: Int,
+            val ratedAt: Instant,
+        )
+
+        @Immutable
+        data class Commented(
+            val id: TraktId,
+            val comment: String,
+            val spoiler: Boolean,
+            val review: Boolean,
+            val createdAt: Instant,
+            val updatedAt: Instant,
+        )
+    }
+
+    @Immutable
+    data class Watchlisted(
+        val listedAt: Instant,
+    )
+
+    companion object {
+        fun fromDto(
+            dto: V3MediaSocialResponse,
+            type: MediaType,
+        ): MediaSocialActivity {
+            return MediaSocialActivity(
+                type = type,
+                user = User.fromDto(dto.user),
+                watched = dto.watched?.let { watched ->
+                    Watched(
+                        lastWatchedAt = watched.lastWatchedAt.toInstant(),
+                        lastUpdatedAt = watched.lastUpdatedAt?.toInstant(),
+                        plays = watched.plays,
+                        rated = watched.rated?.let { rated ->
+                            Watched.Rated(
+                                rating = rated.rating,
+                                ratedAt = rated.ratedAt.toInstant(),
+                            )
+                        },
+                        commented = watched.commented?.let { commented ->
+                            Watched.Commented(
+                                id = commented.id.trakt.toTraktId(),
+                                comment = commented.comment,
+                                spoiler = commented.spoiler,
+                                review = commented.review,
+                                createdAt = commented.createdAt.toInstant(),
+                                updatedAt = commented.updatedAt.toInstant(),
+                            )
+                        },
+                    )
+                },
+                watchlisted = dto.watchlisted?.let { watchlisted ->
+                    Watchlisted(
+                        listedAt = watchlisted.listedAt.toInstant(),
+                    )
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/ui/MediaSocialItemCard.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/ui/MediaSocialItemCard.kt
@@ -1,0 +1,230 @@
+package tv.trakt.trakt.core.summary.social.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.ColorImage
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.AsyncImagePreviewHandler
+import coil3.compose.LocalAsyncImagePreviewHandler
+import tv.trakt.trakt.common.helpers.extensions.DevicePreview
+import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
+import tv.trakt.trakt.common.helpers.extensions.onClick
+import tv.trakt.trakt.common.helpers.extensions.onClickCombined
+import tv.trakt.trakt.common.helpers.extensions.relativePastDateString
+import tv.trakt.trakt.common.helpers.extensions.toLocal
+import tv.trakt.trakt.common.helpers.preview.PreviewData
+import tv.trakt.trakt.common.model.MediaType.SHOW
+import tv.trakt.trakt.common.model.toTraktId
+import tv.trakt.trakt.common.ui.theme.colors.Shade940
+import tv.trakt.trakt.core.profile.sections.social.ui.SocialUserView
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity.Watched.Rated
+import tv.trakt.trakt.resources.R
+import tv.trakt.trakt.ui.components.chips.InfoChip
+import tv.trakt.trakt.ui.theme.TraktTheme
+import java.util.Locale
+import kotlin.time.Duration.Companion.days
+
+@Composable
+internal fun MediaSocialItemCard(
+    item: MediaSocialActivity,
+    modifier: Modifier = Modifier,
+    corner: Dp = 24.dp,
+    shadow: Dp = 0.dp,
+    containerColor: Color = TraktTheme.colors.panelCardContainer,
+    onClick: () -> Unit = {},
+    onUserClick: () -> Unit = {},
+    onReviewClick: () -> Unit = {},
+) {
+    Row(
+        horizontalArrangement = spacedBy(0.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .dropShadow(
+                shape = RoundedCornerShape(corner),
+                shadow = Shadow(
+                    radius = shadow,
+                    color = Shade940,
+                    spread = 2.dp,
+                    alpha = if (shadow > 0.dp) 0.1F else 0F,
+                ),
+            )
+            .graphicsLayer {
+                clip = false
+            }
+            .background(containerColor, RoundedCornerShape(corner))
+            .onClickCombined(onClick = onClick)
+            .padding(12.dp),
+    ) {
+        SocialUserView(
+            user = item.user,
+            size = 52.dp,
+            showName = false,
+            onUserClick = onUserClick,
+        )
+
+        Column(
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .padding(start = 12.dp)
+                .padding(end = 4.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = item.user.displayName,
+                        style = TraktTheme.typography.cardTitle.copy(fontSize = 16.sp),
+                        color = TraktTheme.colors.textPrimary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 16.dp)
+                            .onClick {
+                                onUserClick()
+                            },
+                    )
+
+                    Text(
+                        text = item.lastActivityAt.toLocal().relativePastDateString(),
+                        style = TraktTheme.typography.cardSubtitle.copy(fontSize = 11.sp),
+                        color = TraktTheme.colors.textSecondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier
+                        .weight(1F)
+                        .padding(end = 4.dp),
+                ) {
+                    item.watched?.let {
+                        InfoChip(
+                            iconPainter = painterResource(R.drawable.ic_check_double),
+                            iconPadding = 1.dp,
+                            text = stringResource(
+                                when (item.type) {
+                                    SHOW -> R.string.tag_text_number_of_episodes
+                                    else -> R.string.text_play_count
+                                },
+                                it.plays,
+                            ),
+                        )
+                    }
+
+                    item.watchlisted?.let {
+                        InfoChip(
+                            iconPainter = painterResource(R.drawable.ic_bookmark_on),
+                            text = stringResource(R.string.list_title_watchlist),
+                        )
+                    }
+                }
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    item.watched?.commented?.let {
+                        InfoChip(
+                            iconPainter = painterResource(R.drawable.ic_comment),
+                            text = stringResource(R.string.dialog_title_comment),
+                        )
+                    }
+
+                    item.watched?.rated?.let {
+                        val ratingText = remember(it.rating) {
+                            "%.1f"
+                                .format(Locale.US, it.rating / 2f)
+                                .removeSuffix(".0")
+                                .removeSuffix(",0")
+                        }
+                        InfoChip(
+                            iconPainter = painterResource(R.drawable.ic_star),
+                            text = ratingText,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalCoilApi::class)
+@DevicePreview
+@Composable
+private fun PosterPreview() {
+    TraktTheme {
+        val previewHandler = AsyncImagePreviewHandler {
+            ColorImage(Color.Blue.toArgb())
+        }
+        CompositionLocalProvider(LocalAsyncImagePreviewHandler provides previewHandler) {
+            MediaSocialItemCard(
+                item = MediaSocialActivity(
+                    type = SHOW,
+                    user = PreviewData.user1,
+                    watched = MediaSocialActivity.Watched(
+                        lastWatchedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                        lastUpdatedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                        plays = 3,
+                        rated = Rated(
+                            rating = 8,
+                            ratedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                        ),
+                        commented = MediaSocialActivity.Watched.Commented(
+                            id = 1.toTraktId(),
+                            comment = "Sample comment by someone",
+                            spoiler = false,
+                            review = false,
+                            createdAt = nowUtcInstant(),
+                            updatedAt = nowUtcInstant(),
+                        ),
+                    ),
+                    watchlisted = MediaSocialActivity.Watchlisted(
+                        listedAt = nowUtcInstant().minusSeconds(3.days.inWholeSeconds),
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/summary/social/ui/MediaSocialItemCard.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/social/ui/MediaSocialItemCard.kt
@@ -57,7 +57,6 @@ internal fun MediaSocialItemCard(
     containerColor: Color = TraktTheme.colors.panelCardContainer,
     onClick: () -> Unit = {},
     onUserClick: () -> Unit = {},
-    onReviewClick: () -> Unit = {},
 ) {
     Row(
         horizontalArrangement = spacedBy(0.dp),
@@ -130,7 +129,7 @@ internal fun MediaSocialItemCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 10.dp),
+                    .padding(top = 8.dp),
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/EpisodeDetailsHeader.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/EpisodeDetailsHeader.kt
@@ -1,14 +1,19 @@
 package tv.trakt.trakt.core.summary.ui.header
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -19,8 +24,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import tv.trakt.trakt.common.Config.webImdbMediaUrl
 import tv.trakt.trakt.common.core.translations.model.MediaTranslation
+import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
 import tv.trakt.trakt.common.helpers.extensions.capitalize
 import tv.trakt.trakt.common.helpers.extensions.mediumDateFormat
 import tv.trakt.trakt.common.helpers.extensions.onClick
@@ -30,6 +38,8 @@ import tv.trakt.trakt.common.model.Episode
 import tv.trakt.trakt.common.model.ExternalRating
 import tv.trakt.trakt.common.model.Person
 import tv.trakt.trakt.common.model.Show
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+import tv.trakt.trakt.core.summary.ui.header.social.DetailsHeaderSocialHorizontalChip
 import tv.trakt.trakt.resources.R
 import tv.trakt.trakt.ui.theme.TraktTheme
 
@@ -38,6 +48,7 @@ internal fun DetailsHeader(
     episode: Episode,
     show: Show,
     episodeTranslation: MediaTranslation?,
+    episodeSocials: ImmutableList<MediaSocialActivity>?,
     ratings: ExternalRating?,
     creator: Person?,
     playsCount: Int?,
@@ -45,6 +56,7 @@ internal fun DetailsHeader(
     onShowClick: (Show) -> Unit,
     onCreatorClick: (Person) -> Unit,
     onShareClick: () -> Unit,
+    onSocialActivityClick: () -> Unit,
     onInfoClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -190,6 +202,27 @@ internal fun DetailsHeader(
         onInfoClick = onInfoClick,
         onShareClick = onShareClick,
         onShareImageClick = {},
+        extraRightColumn = {
+            val users = remember(episodeSocials?.size) {
+                episodeSocials?.map { it.user }?.toImmutableList()
+            }
+            AnimatedVisibility(
+                visible = !users.isNullOrEmpty(),
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                ) {
+                    DetailsHeaderSocialHorizontalChip(
+                        users = users ?: EmptyImmutableList,
+                        size = 22.dp,
+                        spacing = 14,
+                        modifier = Modifier.onClick { onSocialActivityClick() },
+                    )
+                }
+            }
+        },
         onImdbClick = {
             val uri = when {
                 episode.ids.imdb != null -> webImdbMediaUrl(episode.ids.imdb!!.value)

--- a/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/MovieDetailsHeader.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/MovieDetailsHeader.kt
@@ -1,9 +1,14 @@
 package tv.trakt.trakt.core.summary.ui.header
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,8 +22,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import tv.trakt.trakt.common.Config.webImdbMediaUrl
 import tv.trakt.trakt.common.core.translations.model.MediaTranslation
+import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
 import tv.trakt.trakt.common.helpers.extensions.capitalize
 import tv.trakt.trakt.common.helpers.extensions.mediumDateFormat
 import tv.trakt.trakt.common.helpers.extensions.onClick
@@ -27,6 +35,8 @@ import tv.trakt.trakt.common.model.ExternalRating
 import tv.trakt.trakt.common.model.Images
 import tv.trakt.trakt.common.model.Movie
 import tv.trakt.trakt.common.model.Person
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+import tv.trakt.trakt.core.summary.ui.header.social.DetailsHeaderSocialVerticalChip
 import tv.trakt.trakt.resources.R
 import tv.trakt.trakt.ui.theme.TraktTheme
 
@@ -34,6 +44,7 @@ import tv.trakt.trakt.ui.theme.TraktTheme
 internal fun DetailsHeader(
     movie: Movie,
     movieTranslation: MediaTranslation?,
+    movieSocials: ImmutableList<MediaSocialActivity>?,
     ratings: ExternalRating?,
     creator: Person?,
     playsCount: Int?,
@@ -42,6 +53,7 @@ internal fun DetailsHeader(
     onCreatorClick: (Person) -> Unit,
     onShareClick: () -> Unit,
     onShareImageClick: () -> Unit,
+    onSocialActivityClick: () -> Unit,
     onInfoClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -106,6 +118,30 @@ internal fun DetailsHeader(
                             }
                         },
                 )
+            }
+        },
+        extraRightColumn = {
+            val users = remember(movieSocials?.size) {
+                movieSocials?.map { it.user }?.toImmutableList()
+            }
+            AnimatedVisibility(
+                visible = !users.isNullOrEmpty(),
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 19.dp),
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                ) {
+                    DetailsHeaderSocialVerticalChip(
+                        users = users ?: EmptyImmutableList,
+                        size = 28.dp,
+                        spacing = 20,
+                        modifier = Modifier.onClick { onSocialActivityClick() },
+                    )
+                }
             }
         },
         genres = movie.genres,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/ShowDetailsHeader.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/ShowDetailsHeader.kt
@@ -1,9 +1,14 @@
 package tv.trakt.trakt.core.summary.ui.header
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,8 +22,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import tv.trakt.trakt.common.Config.webImdbMediaUrl
 import tv.trakt.trakt.common.core.translations.model.MediaTranslation
+import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
 import tv.trakt.trakt.common.helpers.extensions.capitalize
 import tv.trakt.trakt.common.helpers.extensions.mediumDateFormat
 import tv.trakt.trakt.common.helpers.extensions.onClick
@@ -28,6 +36,8 @@ import tv.trakt.trakt.common.model.ExternalRating
 import tv.trakt.trakt.common.model.Images.Size
 import tv.trakt.trakt.common.model.Person
 import tv.trakt.trakt.common.model.Show
+import tv.trakt.trakt.core.summary.social.model.MediaSocialActivity
+import tv.trakt.trakt.core.summary.ui.header.social.DetailsHeaderSocialVerticalChip
 import tv.trakt.trakt.resources.R
 import tv.trakt.trakt.ui.theme.TraktTheme
 
@@ -35,6 +45,7 @@ import tv.trakt.trakt.ui.theme.TraktTheme
 internal fun DetailsHeader(
     show: Show,
     showTranslation: MediaTranslation?,
+    showSocials: ImmutableList<MediaSocialActivity>?,
     ratings: ExternalRating?,
     creator: Person?,
     airedCount: Int,
@@ -43,6 +54,7 @@ internal fun DetailsHeader(
     onCreatorClick: (Person) -> Unit,
     onShareClick: () -> Unit,
     onShareImageClick: () -> Unit,
+    onSocialActivityClick: () -> Unit,
     onInfoClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -116,6 +128,30 @@ internal fun DetailsHeader(
                             }
                         },
                 )
+            }
+        },
+        extraRightColumn = {
+            val users = remember(showSocials?.size) {
+                showSocials?.map { it.user }?.toImmutableList()
+            }
+            AnimatedVisibility(
+                visible = !users.isNullOrEmpty(),
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 19.dp),
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                ) {
+                    DetailsHeaderSocialVerticalChip(
+                        users = users ?: EmptyImmutableList,
+                        size = 28.dp,
+                        spacing = 20,
+                        modifier = Modifier.onClick { onSocialActivityClick() },
+                    )
+                }
             }
         },
         genres = show.genres,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/poster/DetailsHeaderPosterHorizontal.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/poster/DetailsHeaderPosterHorizontal.kt
@@ -99,6 +99,8 @@ fun DetailsHeaderPosterHorizontal(
                 horizontalArrangement = spacedBy(20.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                extraRightColumn.invoke()
+
                 Icon(
                     painter = painterResource(R.drawable.ic_share),
                     tint = TraktTheme.colors.textPrimary,
@@ -107,8 +109,6 @@ fun DetailsHeaderPosterHorizontal(
                         .size(22.dp)
                         .onClick(onClick = onShareClick),
                 )
-
-                extraRightColumn.invoke()
             }
         }
 

--- a/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/social/DetailsHeaderSocialChip.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/ui/header/social/DetailsHeaderSocialChip.kt
@@ -1,0 +1,188 @@
+package tv.trakt.trakt.core.summary.ui.header.social
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import coil3.compose.AsyncImage
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import tv.trakt.trakt.common.helpers.preview.PreviewData
+import tv.trakt.trakt.common.model.User
+import tv.trakt.trakt.common.ui.theme.colors.Red500
+import tv.trakt.trakt.resources.R
+import tv.trakt.trakt.ui.theme.TraktTheme
+
+private const val USERS_LIMIT = 3
+
+@Composable
+internal fun DetailsHeaderSocialHorizontalChip(
+    modifier: Modifier = Modifier,
+    users: ImmutableList<User>,
+    size: Dp = 32.dp,
+    spacing: Int = 20,
+) {
+    val limitUsers = remember(users.size) { users.take(USERS_LIMIT) }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = spacedBy(4.dp),
+    ) {
+        Box {
+            limitUsers.forEachIndexed { index, user ->
+                val offset = (index * spacing).dp
+                AsyncImage(
+                    model = user.images?.avatar?.full,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    placeholder = painterResource(R.drawable.ic_person_placeholder),
+                    error = painterResource(R.drawable.ic_person_placeholder),
+                    modifier = Modifier
+                        .zIndex(10 - index.toFloat())
+                        .padding(start = offset)
+                        .size(size)
+                        .border(
+                            width = 1.25.dp,
+                            color = if (user.isAnyVip) Red500 else Color.Transparent,
+                            shape = CircleShape,
+                        )
+                        .clip(CircleShape),
+                )
+            }
+        }
+
+        if (users.isNotEmpty()) {
+            UsersCount(
+                count = users.size,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun DetailsHeaderSocialVerticalChip(
+    modifier: Modifier = Modifier,
+    users: ImmutableList<User>,
+    size: Dp = 32.dp,
+    spacing: Int = 20,
+) {
+    val limitUsers = remember(users.size) { users.take(USERS_LIMIT) }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = spacedBy(4.dp),
+    ) {
+        Box {
+            limitUsers.forEachIndexed { index, user ->
+                val offset = (index * spacing).dp
+                AsyncImage(
+                    model = user.images?.avatar?.full,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    placeholder = painterResource(R.drawable.ic_person_placeholder),
+                    error = painterResource(R.drawable.ic_person_placeholder),
+                    modifier = Modifier
+                        .zIndex(10 - index.toFloat())
+                        .padding(top = offset)
+                        .size(size)
+                        .border(
+                            width = 1.25.dp,
+                            color = if (user.isAnyVip) Red500 else Color.Transparent,
+                            shape = CircleShape,
+                        )
+                        .clip(CircleShape),
+                )
+            }
+        }
+
+        if (users.isNotEmpty()) {
+            UsersCount(
+                count = users.size,
+            )
+        }
+    }
+}
+
+@Composable
+private fun UsersCount(count: Int) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = spacedBy(0.25.dp),
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_person),
+            contentDescription = null,
+            tint = TraktTheme.colors.textPrimary,
+            modifier = Modifier.size(14.dp),
+        )
+        Text(
+            text = "$count",
+            color = TraktTheme.colors.textPrimary,
+            style = TraktTheme.typography.meta,
+        )
+    }
+}
+
+@Preview(
+    device = "id:pixel_5",
+    showBackground = true,
+    backgroundColor = 0xFF212427,
+)
+@Composable
+private fun DetailsHeaderSocialHorizontalChipPreview() {
+    TraktTheme {
+        DetailsHeaderSocialHorizontalChip(
+            users = listOf(
+                PreviewData.user1,
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+            )
+                .toImmutableList(),
+        )
+    }
+}
+
+@Preview(
+    device = "id:pixel_5",
+    showBackground = true,
+    backgroundColor = 0xFF212427,
+)
+@Composable
+private fun DetailsHeaderSocialVerticalChipPreview() {
+    TraktTheme {
+        DetailsHeaderSocialVerticalChip(
+            users = listOf(
+                PreviewData.user1,
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+                PreviewData.user1.copy(isVip = true),
+            )
+                .toImmutableList(),
+        )
+    }
+}

--- a/common/src/main/java/tv/trakt/trakt/common/networking/OpenApiAliases.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/networking/OpenApiAliases.kt
@@ -100,6 +100,7 @@ typealias ListMediaItemDto = GetUsersWatchlistAll200ResponseInner
 typealias ListItemDto = GetUsersListsListItemsAll200ResponseInner
 typealias UserSettingsDto = GetUsersSettings200Response
 typealias UserReactionDto = GetUsersReactionsComments200ResponseInner
+typealias UserMediaDto = GetUsersReactionsComments200ResponseInnerCommentUser
 typealias UserCommentsDto = GetUsersReactionsComments200ResponseInnerCommentUser
 typealias UserBlockedDto = GetUsersReactionsComments200ResponseInnerCommentUser
 typealias StreamingDto = GetMoviesWatchnow200ResponseValue

--- a/common/src/main/java/tv/trakt/trakt/common/networking/api/v3/V3Api.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/networking/api/v3/V3Api.kt
@@ -6,7 +6,9 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.request.get
 import org.openapitools.client.infrastructure.ApiClient
 import tv.trakt.trakt.common.model.TraktId
+import tv.trakt.trakt.common.model.pagination.Pagination
 import tv.trakt.trakt.common.model.toTraktId
+import tv.trakt.trakt.common.networking.api.v3.model.V3MediaSocialResponse
 import tv.trakt.trakt.common.networking.api.v3.model.V3MinimalList
 import tv.trakt.trakt.common.networking.api.v3.model.V3MinimalWatchlistResponse
 import tv.trakt.trakt.common.networking.api.v3.model.V3SentimentResponse
@@ -14,15 +16,16 @@ import tv.trakt.trakt.common.networking.api.v3.model.V3TriviaResponse
 
 class V3Api(
     private val baseUrl: String,
+    private val baseV3Url: String,
     httpClientEngine: HttpClientEngine,
     httpClientConfig: ((HttpClientConfig<*>) -> Unit),
 ) : ApiClient(
-        baseUrl,
+        baseV3Url,
         httpClientEngine,
         httpClientConfig,
     ) {
     suspend fun getWatchlistMinimal(): Pair<Set<TraktId>, Set<TraktId>> {
-        val response = client.get("${baseUrl}users/me/watchlist/minimal")
+        val response = client.get("${baseV3Url}users/me/watchlist/minimal")
         val responseBody = response.body<V3MinimalWatchlistResponse>()
 
         val shows = responseBody.shows.orEmpty().map { it.toTraktId() }.toSet()
@@ -34,41 +37,81 @@ class V3Api(
     // Lists Management
 
     suspend fun getListsMinimal(): List<V3MinimalList> {
-        val response = client.get("${baseUrl}users/me/lists")
+        val response = client.get("${baseV3Url}users/me/lists")
         return response.body()
     }
 
     suspend fun getMovieMeLists(movieId: TraktId): List<Int> {
-        val response = client.get("${baseUrl}movies/${movieId.value}/me/lists")
+        val response = client.get("${baseV3Url}movies/${movieId.value}/me/lists")
         return response.body<List<Int>>()
     }
 
     suspend fun getShowMeLists(showId: TraktId): List<Int> {
-        val response = client.get("${baseUrl}shows/${showId.value}/me/lists")
+        val response = client.get("${baseV3Url}shows/${showId.value}/me/lists")
         return response.body<List<Int>>()
     }
 
     // Sentiment
 
     suspend fun getMovieSentiment(movieId: TraktId): V3SentimentResponse? {
-        val response = client.get("${baseUrl}media/movie/${movieId.value}/info/0/version/1")
+        val response = client.get("${baseV3Url}media/movie/${movieId.value}/info/0/version/1")
         return response.body()
     }
 
     suspend fun getShowSentiment(showId: TraktId): V3SentimentResponse? {
-        val response = client.get("${baseUrl}media/show/${showId.value}/info/0/version/1")
+        val response = client.get("${baseV3Url}media/show/${showId.value}/info/0/version/1")
         return response.body()
     }
 
     // Trivia
 
     suspend fun getShowTrivia(showId: TraktId): V3TriviaResponse {
-        val response = client.get("${baseUrl}media/show/${showId.value}/info/5/version/1")
+        val response = client.get("${baseV3Url}media/show/${showId.value}/info/5/version/1")
         return response.body<V3TriviaResponse>()
     }
 
     suspend fun getMovieTrivia(movieId: TraktId): V3TriviaResponse {
-        val response = client.get("${baseUrl}media/movie/${movieId.value}/info/5/version/1")
+        val response = client.get("${baseV3Url}media/movie/${movieId.value}/info/5/version/1")
         return response.body<V3TriviaResponse>()
+    }
+
+    // Social
+
+    suspend fun getMovieSocialActivity(
+        movieId: TraktId,
+        pagination: Pagination,
+    ): List<V3MediaSocialResponse>? {
+        val response = client.get(
+            "${baseUrl}movies/${movieId.value}/social" +
+                "?page=${pagination.page}" +
+                "&limit=${pagination.limit}",
+        )
+        return response.body()
+    }
+
+    suspend fun getShowSocialActivity(
+        showId: TraktId,
+        pagination: Pagination,
+    ): List<V3MediaSocialResponse>? {
+        val response = client.get(
+            "${baseUrl}shows/${showId.value}/social" +
+                "?page=${pagination.page}" +
+                "&limit=${pagination.limit}",
+        )
+        return response.body()
+    }
+
+    suspend fun getEpisodeSocialActivity(
+        showId: TraktId,
+        season: Int,
+        episode: Int,
+        pagination: Pagination,
+    ): List<V3MediaSocialResponse>? {
+        val response = client.get(
+            "${baseUrl}shows/${showId.value}/seasons/$season/episodes/$episode/social" +
+                "?page=${pagination.page}" +
+                "&limit=${pagination.limit}",
+        )
+        return response.body()
     }
 }

--- a/common/src/main/java/tv/trakt/trakt/common/networking/api/v3/model/V3MediaSocialResponse.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/networking/api/v3/model/V3MediaSocialResponse.kt
@@ -1,0 +1,65 @@
+package tv.trakt.trakt.common.networking.api.v3.model
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import tv.trakt.trakt.common.networking.UserMediaDto
+
+@Immutable
+@Serializable
+data class V3MediaSocialResponse(
+    val user: UserMediaDto,
+    @SerialName("followed_at")
+    val followedAt: String,
+    val watched: Watched?,
+    val watchlisted: Watchlisted?,
+) {
+    @Immutable
+    @Serializable
+    data class Watched(
+        @SerialName("last_watched_at")
+        val lastWatchedAt: String,
+        @SerialName("last_updated_at")
+        val lastUpdatedAt: String?,
+        val plays: Int,
+        @SerialName("rating")
+        val rated: Rated?,
+        @SerialName("comment")
+        val commented: Commented?,
+    ) {
+        @Immutable
+        @Serializable
+        data class Rated(
+            val rating: Int,
+            @SerialName("rated_at")
+            val ratedAt: String,
+        )
+
+        @Immutable
+        @Serializable
+        data class Commented(
+            @SerialName("ids")
+            val id: CommentedId,
+            val comment: String,
+            val spoiler: Boolean,
+            val review: Boolean,
+            @SerialName("created_at")
+            val createdAt: String,
+            @SerialName("updated_at")
+            val updatedAt: String,
+        ) {
+            @Immutable
+            @Serializable
+            data class CommentedId(
+                val trakt: Int,
+            )
+        }
+    }
+
+    @Immutable
+    @Serializable
+    data class Watchlisted(
+        @SerialName("listed_at")
+        val listedAt: String,
+    )
+}

--- a/common/src/main/java/tv/trakt/trakt/common/networking/di/NetworkingModule.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/networking/di/NetworkingModule.kt
@@ -104,7 +104,8 @@ val networkingApiModule = module {
 
     single<V3Api> {
         V3Api(
-            baseUrl = API_V3_BASE_URL,
+            baseUrl = API_BASE_URL,
+            baseV3Url = API_V3_BASE_URL,
             httpClientEngine = get(),
             httpClientConfig = get<(HttpClientConfig<*>) -> Unit>(named("authorizedClientConfig")),
         )


### PR DESCRIPTION
## Summary
  - Add social activity chip + bottom sheet to movie, show, and episode details headers, showing friends watching/rating/checking-in on the media.

Related to trakt/trakt-web#2630

  ## Test plan
  - [ ] Open movie/show/episode summary — social chip renders when friends have activity, hides when empty.
  - [ ] Tap chip → bottom sheet lists watch/rate/checkin entries with avatars.

<img height="800" alt="image" src="https://github.com/user-attachments/assets/b5a3d224-02ce-476f-abc6-8214f29c8787" />
<img height="800" alt="image" src="https://github.com/user-attachments/assets/c0de2f36-9104-478f-a56b-584ac2e1f303" />

