### PR TITLE
feat: introduce screen time to the profile

### DIFF
--- a/.agents/rules/architecture.md
+++ b/.agents/rules/architecture.md
@@ -1,7 +1,7 @@
 ---
 trigger: glob
 globs: '**/*.kt'
-description: 'MVVM + UDF, Compose-only UI, ViewModel + StateFlow, sealed UiState, Compose Navigation typed routes, repositories. Background sync, adaptive layouts.'
+description: 'MVVM + UDF, Compose-only UI, ViewModel + StateFlow, Compose Navigation typed routes, repositories. Background sync, adaptive layouts.'
 applyTo: '**/*.kt'
 ---
 

--- a/.agents/rules/state-management.md
+++ b/.agents/rules/state-management.md
@@ -18,23 +18,6 @@ applyTo: '{app,tv,common}/src/main/**/*.kt'
 | Derived value reactive to other state                | `val x by remember(...) { derivedStateOf { … } }`      |
 | Side effects keyed to recomposition                  | `LaunchedEffect(key)`, `DisposableEffect(key)`         |
 
-## Sealed UiState
-
-Every screen has sealed UI state hierarchy:
-
-```kotlin
-sealed interface MovieSummaryUiState {
-    data object Loading : MovieSummaryUiState
-    data class Loaded(val movie: Movie) : MovieSummaryUiState
-    data class Error(val throwable: Throwable) : MovieSummaryUiState
-}
-```
-
-- **No `data class … (val movie: Movie?, val isLoading: Boolean, val error: Throwable?)`**
-  flat shapes. Use sealed types — impossible combinations stay impossible.
-- `@Immutable` on `Loaded`-style data classes holding collections. Compose skips recomposition when refs stable.
-- For collections in state, prefer `ImmutableList` (`kotlinx.collections.immutable`) over `List<T>` — Compose treats immutable types as stable.
-
 ## ViewModel
 
 One `state: StateFlow<UiState>` per ViewModel. Build from upstream Flows, expose via `stateIn(viewModelScope, WhileSubscribed(5_000), initial)`. Internal mutable signals private:

--- a/app/src/main/java/tv/trakt/trakt/core/profile/ProfileScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/ProfileScreen.kt
@@ -73,6 +73,7 @@ import tv.trakt.trakt.core.profile.sections.favorites.ProfileFavoritesView
 import tv.trakt.trakt.core.profile.sections.history.ProfileHistoryView
 import tv.trakt.trakt.core.profile.sections.library.ProfileLibraryView
 import tv.trakt.trakt.core.profile.sections.progress.ProfileProgressView
+import tv.trakt.trakt.core.profile.sections.screentime.ProfileScreenTimeView
 import tv.trakt.trakt.core.profile.sections.social.ProfileSocialView
 import tv.trakt.trakt.core.profile.sections.thismonth.ProfileStatsCard
 import tv.trakt.trakt.helpers.SimpleScrollConnection
@@ -172,7 +173,7 @@ private fun ProfileScreen(
     onSettingsClick: () -> Unit = {},
     onLogoutClick: () -> Unit = {},
 ) {
-    val inspection = LocalInspectionMode.current
+    val preview = LocalInspectionMode.current
     val windowClass = currentWindowAdaptiveInfo().windowSizeClass
 
     val listPadding = PaddingValues(
@@ -298,7 +299,29 @@ private fun ProfileScreen(
                     }
                 }
 
-                if (!inspection) {
+                if (!preview) {
+                    item {
+                        ProfileFavoritesView(
+                            headerPadding = sectionPadding,
+                            contentPadding = sectionPadding,
+                            onShowClick = onNavigateToShow,
+                            onMovieClick = onNavigateToMovie,
+                            onMoreClick = onNavigateToFavorites,
+                            onShowsClick = onNavigateToShows,
+                            modifier = Modifier
+                                .padding(bottom = TraktTheme.spacing.mainSectionVerticalSpace),
+                        )
+                    }
+
+                    item {
+                        ProfileScreenTimeView(
+                            headerPadding = sectionPadding,
+                            contentPadding = sectionPadding,
+                            modifier = Modifier
+                                .padding(bottom = TraktTheme.spacing.mainSectionVerticalSpace),
+                        )
+                    }
+
                     item {
                         ProfileHistoryView(
                             headerPadding = sectionPadding,
@@ -331,19 +354,6 @@ private fun ProfileScreen(
                             contentPadding = sectionPadding,
                             onShowClick = onNavigateToShow,
                             onMoreClick = onNavigateToProgress,
-                            modifier = Modifier
-                                .padding(bottom = TraktTheme.spacing.mainSectionVerticalSpace),
-                        )
-                    }
-
-                    item {
-                        ProfileFavoritesView(
-                            headerPadding = sectionPadding,
-                            contentPadding = sectionPadding,
-                            onShowClick = onNavigateToShow,
-                            onMovieClick = onNavigateToMovie,
-                            onMoreClick = onNavigateToFavorites,
-                            onShowsClick = onNavigateToShows,
                             modifier = Modifier
                                 .padding(bottom = TraktTheme.spacing.mainSectionVerticalSpace),
                         )

--- a/app/src/main/java/tv/trakt/trakt/core/profile/di/ProfileModule.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/di/ProfileModule.kt
@@ -69,6 +69,12 @@ import tv.trakt.trakt.core.profile.sections.progress.filters.GetProgressFilterUs
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressCompleteUseCase
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressDroppedUseCase
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressWatchingUseCase
+import tv.trakt.trakt.core.profile.sections.screentime.ProfileScreenTimeViewModel
+import tv.trakt.trakt.core.profile.sections.screentime.all.ScreenTimeAllViewModel
+import tv.trakt.trakt.core.profile.sections.screentime.data.local.ScreenTimeLocalDataSource
+import tv.trakt.trakt.core.profile.sections.screentime.data.local.ScreenTimeStorage
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import tv.trakt.trakt.core.profile.sections.screentime.usecase.GetScreenTimeUseCase
 import tv.trakt.trakt.core.profile.sections.social.ProfileSocialViewModel
 import tv.trakt.trakt.core.profile.sections.social.usecases.GetSocialFilterUseCase
 import tv.trakt.trakt.core.profile.sections.thismonth.usecases.GetProfileStatsUseCase
@@ -213,6 +219,10 @@ internal val profileDataModule = module {
         ProgressDroppedStorage()
     }
 
+    single<ScreenTimeLocalDataSource> {
+        ScreenTimeStorage()
+    }
+
     single<ProfileRatingsLocalDataSource> {
         ProfileRatingsStorage()
     }
@@ -352,6 +362,13 @@ internal val profileModule = module {
         )
     }
 
+    factory {
+        GetScreenTimeUseCase(
+            remoteSource = get(),
+            localDataSource = get(),
+        )
+    }
+
     single<ProgressUpdates> {
         ProgressUpdatesStorage()
     }
@@ -402,6 +419,7 @@ internal val profileModule = module {
             localUserReactions = get(),
             localUserRatings = get(),
             localProfileDropped = get(),
+            localScreenTime = get(),
             localProfileWatching = get(),
             localProfileCompleted = get(),
             localProfileRatings = get(),
@@ -461,6 +479,13 @@ internal val profileModule = module {
     }
 
     viewModelOf(::ProfileActivityViewModel)
+    viewModelOf(::ProfileScreenTimeViewModel)
+
+    viewModel { (data: ScreenTimeData) ->
+        ScreenTimeAllViewModel(
+            data = data,
+        )
+    }
 
     viewModel {
         ProfileAllActivityViewModel(

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/history/ProfileHistoryViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/history/ProfileHistoryViewModel.kt
@@ -91,11 +91,11 @@ internal class ProfileHistoryViewModel(
         loadData()
         loadUserRatingData()
 
-        observeHome()
+        observeData()
         observeRatings()
     }
 
-    private fun observeHome() {
+    private fun observeData() {
         merge(
             allActivitySource.observeUpdates(),
             movieUpdates.observeUpdates(),

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ProfileScreenTimeState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ProfileScreenTimeState.kt
@@ -1,0 +1,15 @@
+package tv.trakt.trakt.core.profile.sections.screentime
+
+import androidx.compose.runtime.Immutable
+import tv.trakt.trakt.common.helpers.LoadingState
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import java.time.LocalDate
+
+@Immutable
+internal data class ProfileScreenTimeState(
+    val rangeStart: LocalDate? = null,
+    val data: ScreenTimeData? = null,
+    val loading: LoadingState = LoadingState.Idle,
+    val collapsed: Boolean? = null,
+    val error: Exception? = null,
+)

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ProfileScreenTimeView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ProfileScreenTimeView.kt
@@ -1,0 +1,328 @@
+package tv.trakt.trakt.core.profile.sections.screentime
+
+import androidx.annotation.StringRes
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentMapOf
+import org.koin.androidx.compose.koinViewModel
+import tv.trakt.trakt.common.helpers.LoadingState.Done
+import tv.trakt.trakt.common.helpers.LoadingState.Idle
+import tv.trakt.trakt.common.helpers.LoadingState.Loading
+import tv.trakt.trakt.common.helpers.extensions.mediumDateFormat
+import tv.trakt.trakt.common.helpers.extensions.onClick
+import tv.trakt.trakt.common.helpers.extensions.rememberDurationFormat
+import tv.trakt.trakt.common.ui.theme.colors.Green400
+import tv.trakt.trakt.common.ui.theme.colors.Red400
+import tv.trakt.trakt.core.profile.sections.screentime.all.ScreenTimeAllSheet
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData.Stats
+import tv.trakt.trakt.core.profile.sections.screentime.ui.ScreenTimeDailyBreakdownCard
+import tv.trakt.trakt.core.profile.sections.screentime.ui.ScreenTimePeakHoursCard
+import tv.trakt.trakt.core.profile.sections.screentime.ui.ScreenTimeStatCard
+import tv.trakt.trakt.core.profile.sections.screentime.ui.ScreenTimeStatCardSkeleton
+import tv.trakt.trakt.resources.R
+import tv.trakt.trakt.ui.components.TraktSectionHeader
+import tv.trakt.trakt.ui.theme.TraktTheme
+import java.time.LocalDate
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+internal val StatCardSize = 128.dp
+internal val StatWideCardWidth = 272.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ProfileScreenTimeView(
+    modifier: Modifier = Modifier,
+    viewModel: ProfileScreenTimeViewModel = koinViewModel(),
+    headerPadding: PaddingValues = PaddingValues(),
+    contentPadding: PaddingValues = PaddingValues(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    var screenTimeSheet by remember { mutableStateOf<ScreenTimeData?>(null) }
+
+    ProfileScreenTimeContent(
+        state = state,
+        modifier = modifier,
+        headerPadding = headerPadding,
+        contentPadding = contentPadding,
+        onCollapse = viewModel::setCollapsed,
+        onAllClick = {
+            state.data?.let {
+                screenTimeSheet = it
+            }
+        },
+    )
+
+    screenTimeSheet?.let { data ->
+        ScreenTimeAllSheet(
+            data = data,
+            visible = true,
+            onDismiss = { screenTimeSheet = null },
+        )
+    }
+}
+
+@Composable
+internal fun ProfileScreenTimeContent(
+    state: ProfileScreenTimeState,
+    modifier: Modifier = Modifier,
+    headerPadding: PaddingValues = PaddingValues(),
+    contentPadding: PaddingValues = PaddingValues(),
+    onCollapse: (collapsed: Boolean) -> Unit = {},
+    onAllClick: () -> Unit = {},
+) {
+    val subtitle = state.rangeStart?.let { start ->
+        "${start.format(mediumDateFormat())}  –  ${stringResource(R.string.text_stats_today)}"
+    }
+
+    var animateCollapse by rememberSaveable { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .animateContentSize(
+                animationSpec = if (animateCollapse) spring() else snap(),
+            ),
+    ) {
+        TraktSectionHeader(
+            title = stringResource(R.string.header_screen_time),
+            subtitle = subtitle,
+            chevron = true,
+            collapsed = state.collapsed ?: false,
+            onCollapseClick = {
+                animateCollapse = true
+                val current = (state.collapsed ?: false)
+                onCollapse(!current)
+            },
+            modifier = Modifier
+                .padding(headerPadding)
+                .onClick(
+                    enabled = state.loading.isDone,
+                    onClick = onAllClick,
+                ),
+        )
+
+        if (state.collapsed != true) {
+            Crossfade(
+                targetState = state.loading,
+                animationSpec = tween(200),
+            ) { loading ->
+                when (loading) {
+                    Idle, Loading -> {
+                        ContentLoading(contentPadding = contentPadding)
+                    }
+
+                    Done -> {
+                        if (state.data != null) {
+                            ContentRow(
+                                data = state.data,
+                                contentPadding = contentPadding,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContentRow(
+    data: ScreenTimeData,
+    contentPadding: PaddingValues,
+) {
+    val dataCards = rememberDataCards(data)
+    LazyRow(
+        horizontalArrangement = spacedBy(TraktTheme.spacing.mainRowSpace),
+        contentPadding = contentPadding,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+    ) {
+        item(
+            key = "daily",
+        ) {
+            ScreenTimeDailyBreakdownCard(
+                data = data.dailyHours,
+                modifier = Modifier
+                    .height(StatCardSize)
+                    .width(StatWideCardWidth),
+            )
+        }
+
+        item(
+            key = "peak",
+        ) {
+            ScreenTimePeakHoursCard(
+                data = data.peakHours,
+                modifier = Modifier
+                    .height(StatCardSize)
+                    .width(StatWideCardWidth),
+            )
+        }
+
+        items(
+            items = dataCards,
+            key = { it.labelRes },
+        ) { card ->
+            val changeMinutes = card.change.inWholeMinutes
+            val change = rememberDurationFormat(changeMinutes)
+
+            ScreenTimeStatCard(
+                value = rememberDurationFormat(card.value.inWholeMinutes),
+                label = stringResource(card.labelRes),
+                subtitle = when {
+                    changeMinutes > 0 -> "+$change"
+                    changeMinutes < 0 -> change
+                    else -> stringResource(R.string.text_stats_delta_same)
+                },
+                subtitleColor = when {
+                    changeMinutes > 0 -> Green400
+                    changeMinutes < 0 -> Red400
+                    else -> TraktTheme.colors.textSecondary
+                },
+                modifier = Modifier
+                    .widthIn(min = StatCardSize)
+                    .height(StatCardSize),
+            )
+        }
+
+        item(
+            key = "waking",
+        ) {
+            val change = data.stats.wakingHoursPercentChange
+            ScreenTimeStatCard(
+                value = "${data.stats.wakingHoursPercent}%",
+                label = stringResource(R.string.label_stats_screen_time_share),
+                subtitle = when {
+                    change > 0 -> "+$change%"
+                    change < 0 -> "$change%"
+                    else -> stringResource(R.string.text_stats_delta_same)
+                },
+                subtitleColor = when {
+                    change > 0 -> Green400
+                    change < 0 -> Red400
+                    else -> TraktTheme.colors.textSecondary
+                },
+                modifier = Modifier
+                    .widthIn(min = StatCardSize)
+                    .height(StatCardSize),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ContentLoading(
+    contentPadding: PaddingValues,
+) {
+    LazyRow(
+        horizontalArrangement = spacedBy(TraktTheme.spacing.mainRowSpace),
+        contentPadding = contentPadding,
+        userScrollEnabled = false,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp),
+    ) {
+        repeat(3) {
+            item(
+                key = "loading_$it",
+            ) {
+                ScreenTimeStatCardSkeleton(
+                    modifier = Modifier
+                        .width(StatWideCardWidth)
+                        .height(StatCardSize),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberDataCards(data: ScreenTimeData): List<ScreenTimeStatItem> {
+    return remember(data) {
+        listOf(
+            ScreenTimeStatItem(
+                R.string.label_stats_screen_time_total,
+                data.stats.totalTime,
+                data.stats.totalTimeChange,
+            ),
+            ScreenTimeStatItem(
+                R.string.label_stats_avg_per_day,
+                data.stats.averagePerDay,
+                data.stats.averagePerDayChange,
+            ),
+            ScreenTimeStatItem(
+                R.string.label_stats_shows,
+                data.stats.showsTime,
+                data.stats.showsTimeChange,
+            ),
+            ScreenTimeStatItem(
+                R.string.label_stats_movies,
+                data.stats.moviesTime,
+                data.stats.moviesTimeChange,
+            ),
+        )
+    }
+}
+
+private data class ScreenTimeStatItem(
+    @param:StringRes val labelRes: Int,
+    val value: Duration,
+    val change: Duration,
+)
+
+@Preview
+@Composable
+private fun ProfileScreenTimeContentPreview() {
+    TraktTheme {
+        ProfileScreenTimeContent(
+            state = ProfileScreenTimeState(
+                rangeStart = LocalDate.now().minusDays(6),
+                data = ScreenTimeData(
+                    stats = Stats(
+                        totalTime = 12.hours + 6.minutes,
+                        totalTimeChange = 1.hours + 30.minutes,
+                        averagePerDay = 1.hours + 43.minutes,
+                        averagePerDayChange = 12.minutes,
+                        showsTime = 9.hours,
+                        showsTimeChange = (-45).minutes,
+                        moviesTime = 3.hours + 6.minutes,
+                        moviesTimeChange = Duration.ZERO,
+                        wakingHoursPercent = 10,
+                        wakingHoursPercentChange = -17,
+                    ),
+                    dailyHours = persistentMapOf(),
+                    peakHours = persistentMapOf(),
+                ),
+            ),
+        )
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ProfileScreenTimeViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ProfileScreenTimeViewModel.kt
@@ -1,0 +1,123 @@
+@file:OptIn(FlowPreview::class)
+
+package tv.trakt.trakt.core.profile.sections.screentime
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import tv.trakt.trakt.analytics.crashlytics.recordError
+import tv.trakt.trakt.common.helpers.LoadingState
+import tv.trakt.trakt.common.helpers.LoadingState.Done
+import tv.trakt.trakt.common.helpers.LoadingState.Loading
+import tv.trakt.trakt.common.helpers.extensions.nowLocalDay
+import tv.trakt.trakt.common.helpers.extensions.rethrowCancellation
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import tv.trakt.trakt.core.profile.sections.screentime.usecase.GetScreenTimeUseCase
+import tv.trakt.trakt.core.user.usecases.progress.updates.ProgressUpdates
+import tv.trakt.trakt.helpers.collapsing.CollapsingManager
+import tv.trakt.trakt.helpers.collapsing.model.CollapsingKey
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class ProfileScreenTimeViewModel(
+    private val getScreenTimeUseCase: GetScreenTimeUseCase,
+    private val collapsingManager: CollapsingManager,
+    private val progressUpdates: ProgressUpdates,
+) : ViewModel() {
+    private val initialState = ProfileScreenTimeState(
+        rangeStart = nowLocalDay().minusDays(6),
+    )
+
+    private val dataState = MutableStateFlow(initialState.data)
+    private val loadingState = MutableStateFlow(initialState.loading)
+    private val collapseState = MutableStateFlow(isCollapsed())
+
+    private var collapseJob: Job? = null
+
+    init {
+        loadData()
+        observeProgress()
+    }
+
+    private fun observeProgress() {
+        progressUpdates.observeUpdates()
+            .distinctUntilChanged()
+            .filterNotNull()
+            .debounce(300.milliseconds)
+            .onEach { loadData() }
+            .launchIn(viewModelScope)
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            try {
+                loadingState.update { Loading }
+
+                val local = getScreenTimeUseCase.getLocalScreenTimeData()
+                dataState.update { local }
+
+                loadingState.update {
+                    when (local) {
+                        null -> Loading
+                        else -> Done
+                    }
+                }
+
+                dataState.update {
+                    getScreenTimeUseCase.getScreenTimeData()
+                }
+            } catch (error: Exception) {
+                error.rethrowCancellation {
+                    Timber.recordError(error)
+                }
+            } finally {
+                loadingState.update { Done }
+            }
+        }
+    }
+
+    fun setCollapsed(collapsed: Boolean) {
+        collapseState.update { collapsed }
+
+        collapseJob?.cancel()
+        collapseJob = viewModelScope.launch {
+            when {
+                collapsed -> collapsingManager.collapse(CollapsingKey.PROFILE_SCREEN_TIME)
+                else -> collapsingManager.expand(CollapsingKey.PROFILE_SCREEN_TIME)
+            }
+        }
+    }
+
+    private fun isCollapsed(): Boolean {
+        return collapsingManager.isCollapsed(CollapsingKey.PROFILE_SCREEN_TIME)
+    }
+
+    val state = combine(
+        dataState,
+        loadingState,
+        collapseState,
+    ) { state ->
+        ProfileScreenTimeState(
+            rangeStart = initialState.rangeStart,
+            data = state[0] as ScreenTimeData?,
+            loading = state[1] as LoadingState,
+            collapsed = state[2] as Boolean,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = initialState,
+    )
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllSheet.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllSheet.kt
@@ -1,0 +1,43 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package tv.trakt.trakt.core.profile.sections.screentime.all
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import tv.trakt.trakt.ui.components.TraktBottomSheet
+import kotlin.random.Random.Default.nextInt
+
+@Composable
+internal fun ScreenTimeAllSheet(
+    state: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    data: ScreenTimeData,
+    visible: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val viewModelKey = remember(visible) {
+        nextInt().toString()
+    }
+
+    if (visible) {
+        TraktBottomSheet(
+            sheetState = state,
+            onDismiss = onDismiss,
+        ) {
+            ScreenTimeAllView(
+                viewModel = koinViewModel(key = viewModelKey) { parametersOf(data) },
+                modifier = Modifier
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 8.dp, bottom = 24.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllSheet.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllSheet.kt
@@ -23,7 +23,7 @@ internal fun ScreenTimeAllSheet(
     visible: Boolean,
     onDismiss: () -> Unit,
 ) {
-    val viewModelKey = remember(visible) {
+    val viewModelKey = remember(visible, data) {
         nextInt().toString()
     }
 

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllState.kt
@@ -1,0 +1,11 @@
+package tv.trakt.trakt.core.profile.sections.screentime.all
+
+import androidx.compose.runtime.Immutable
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import java.time.LocalDate
+
+@Immutable
+internal data class ScreenTimeAllState(
+    val rangeStart: LocalDate? = null,
+    val data: ScreenTimeData? = null,
+)

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllView.kt
@@ -1,0 +1,248 @@
+package tv.trakt.trakt.core.profile.sections.screentime.all
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentMapOf
+import tv.trakt.trakt.common.helpers.extensions.DeviceSheetPreview
+import tv.trakt.trakt.common.helpers.extensions.mediumDateFormat
+import tv.trakt.trakt.common.helpers.extensions.rememberDurationFormat
+import tv.trakt.trakt.common.ui.theme.colors.Green400
+import tv.trakt.trakt.common.ui.theme.colors.Red400
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData.Stats
+import tv.trakt.trakt.core.profile.sections.screentime.ui.ScreenTimeDailyBreakdownCard
+import tv.trakt.trakt.core.profile.sections.screentime.ui.ScreenTimePeakHoursCard
+import tv.trakt.trakt.core.profile.sections.screentime.ui.ScreenTimeStatCard
+import tv.trakt.trakt.resources.R
+import tv.trakt.trakt.ui.components.TraktHeader
+import tv.trakt.trakt.ui.theme.TraktTheme
+import java.time.LocalDate
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+private val StatCardHeight = 96.dp
+private val DailyCardHeight = 132.dp
+private val PeakCardHeight = 132.dp
+
+@Composable
+internal fun ScreenTimeAllView(
+    viewModel: ScreenTimeAllViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    state.data?.let { data ->
+        ScreenTimeAllContent(
+            rangeStart = state.rangeStart,
+            data = data,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun ScreenTimeAllContent(
+    rangeStart: LocalDate?,
+    data: ScreenTimeData,
+    modifier: Modifier = Modifier,
+) {
+    val cardColor = TraktTheme.colors.dialogOnContainer
+
+    Column(
+        verticalArrangement = spacedBy(12.dp),
+        modifier = modifier
+            .verticalScroll(
+                state = rememberScrollState(),
+            ),
+    ) {
+        TraktHeader(
+            title = stringResource(R.string.header_screen_time),
+            subtitle = rangeSubtitle(rangeStart),
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        ScreenTimeDailyBreakdownCard(
+            data = data.dailyHours,
+            containerColor = cardColor,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(DailyCardHeight),
+        )
+
+        ScreenTimePeakHoursCard(
+            data = data.peakHours,
+            containerColor = cardColor,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(PeakCardHeight),
+        )
+
+        Row(
+            horizontalArrangement = spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            DurationStatCard(
+                labelRes = R.string.label_stats_screen_time_total,
+                value = data.stats.totalTime,
+                change = data.stats.totalTimeChange,
+                containerColor = cardColor,
+                modifier = Modifier
+                    .weight(1F)
+                    .height(StatCardHeight),
+            )
+            DurationStatCard(
+                labelRes = R.string.label_stats_avg_per_day,
+                value = data.stats.averagePerDay,
+                change = data.stats.averagePerDayChange,
+                containerColor = cardColor,
+                modifier = Modifier
+                    .weight(1F)
+                    .height(StatCardHeight),
+            )
+        }
+
+        Row(
+            horizontalArrangement = spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            DurationStatCard(
+                labelRes = R.string.label_stats_shows,
+                value = data.stats.showsTime,
+                change = data.stats.showsTimeChange,
+                containerColor = cardColor,
+                modifier = Modifier
+                    .weight(1F)
+                    .height(StatCardHeight),
+            )
+            DurationStatCard(
+                labelRes = R.string.label_stats_movies,
+                value = data.stats.moviesTime,
+                change = data.stats.moviesTimeChange,
+                containerColor = cardColor,
+                modifier = Modifier
+                    .weight(1F)
+                    .height(StatCardHeight),
+            )
+        }
+
+        Row(
+            horizontalArrangement = spacedBy(12.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            WakingHoursStatCard(
+                percent = data.stats.wakingHoursPercent,
+                change = data.stats.wakingHoursPercentChange,
+                containerColor = cardColor,
+                modifier = Modifier
+                    .weight(1F)
+                    .height(StatCardHeight),
+            )
+            Spacer(modifier = Modifier.weight(1F))
+        }
+    }
+}
+
+@Composable
+private fun DurationStatCard(
+    @StringRes labelRes: Int,
+    value: Duration,
+    change: Duration,
+    containerColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val changeMinutes = change.inWholeMinutes
+    val changeText = rememberDurationFormat(changeMinutes)
+
+    ScreenTimeStatCard(
+        value = rememberDurationFormat(value.inWholeMinutes),
+        label = stringResource(labelRes),
+        subtitle = when {
+            changeMinutes > 0 -> "+$changeText"
+            changeMinutes < 0 -> changeText
+            else -> stringResource(R.string.text_stats_delta_same)
+        },
+        subtitleColor = when {
+            changeMinutes > 0 -> Green400
+            changeMinutes < 0 -> Red400
+            else -> TraktTheme.colors.textSecondary
+        },
+        containerColor = containerColor,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun WakingHoursStatCard(
+    percent: Int,
+    change: Int,
+    containerColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    ScreenTimeStatCard(
+        value = "$percent%",
+        label = stringResource(R.string.label_stats_screen_time_share),
+        subtitle = when {
+            change > 0 -> "+$change%"
+            change < 0 -> "$change%"
+            else -> stringResource(R.string.text_stats_delta_same)
+        },
+        subtitleColor = when {
+            change > 0 -> Green400
+            change < 0 -> Red400
+            else -> TraktTheme.colors.textSecondary
+        },
+        containerColor = containerColor,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun rangeSubtitle(rangeStart: LocalDate?): String? {
+    rangeStart ?: return null
+    val format = mediumDateFormat()
+    val todayText = stringResource(R.string.text_stats_today)
+    return "${rangeStart.format(format)}  –  $todayText"
+}
+
+@DeviceSheetPreview
+@Composable
+private fun Preview() {
+    TraktTheme {
+        ScreenTimeAllContent(
+            rangeStart = LocalDate.now().minusDays(6),
+            data = ScreenTimeData(
+                stats = Stats(
+                    totalTime = 12.hours + 6.minutes,
+                    totalTimeChange = 1.hours + 30.minutes,
+                    averagePerDay = 1.hours + 43.minutes,
+                    averagePerDayChange = 12.minutes,
+                    showsTime = 9.hours,
+                    showsTimeChange = (-45).minutes,
+                    moviesTime = 3.hours + 6.minutes,
+                    moviesTimeChange = Duration.ZERO,
+                    wakingHoursPercent = 10,
+                    wakingHoursPercentChange = -17,
+                ),
+                dailyHours = persistentMapOf(),
+                peakHours = persistentMapOf(),
+            ),
+            modifier = Modifier.padding(24.dp),
+        )
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/all/ScreenTimeAllViewModel.kt
@@ -1,0 +1,18 @@
+package tv.trakt.trakt.core.profile.sections.screentime.all
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import tv.trakt.trakt.common.helpers.extensions.nowLocalDay
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+
+internal class ScreenTimeAllViewModel(
+    data: ScreenTimeData,
+) : ViewModel() {
+    val state = MutableStateFlow(
+        ScreenTimeAllState(
+            rangeStart = nowLocalDay().minusDays(6),
+            data = data,
+        ),
+    ).asStateFlow()
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/data/local/ScreenTimeLocalDataSource.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/data/local/ScreenTimeLocalDataSource.kt
@@ -1,0 +1,11 @@
+package tv.trakt.trakt.core.profile.sections.screentime.data.local
+
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+
+internal interface ScreenTimeLocalDataSource {
+    suspend fun setData(data: ScreenTimeData)
+
+    suspend fun getData(): ScreenTimeData?
+
+    fun clear()
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/data/local/ScreenTimeStorage.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/data/local/ScreenTimeStorage.kt
@@ -1,0 +1,26 @@
+package tv.trakt.trakt.core.profile.sections.screentime.data.local
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+
+internal class ScreenTimeStorage : ScreenTimeLocalDataSource {
+    private val mutex = Mutex()
+    private var storage: ScreenTimeData? = null
+
+    override suspend fun setData(data: ScreenTimeData) {
+        mutex.withLock {
+            storage = data
+        }
+    }
+
+    override suspend fun getData(): ScreenTimeData? {
+        return mutex.withLock {
+            storage
+        }
+    }
+
+    override fun clear() {
+        storage = null
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/model/ScreenTimeData.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/model/ScreenTimeData.kt
@@ -31,9 +31,9 @@ internal data class ScreenTimeData(
         @param:StringRes val displayRes: Int,
         val period: Pair<LocalTime, LocalTime>,
     ) {
-        Morning(R.string.text_stats_time_morning, LocalTime.of(5, 0) to LocalTime.of(11, 59)),
-        Afternoon(R.string.text_stats_time_afternoon, LocalTime.of(12, 0) to LocalTime.of(16, 59)),
-        Evening(R.string.text_stats_time_evening, LocalTime.of(17, 0) to LocalTime.of(21, 59)),
-        Night(R.string.text_stats_time_late_night, LocalTime.of(22, 0) to LocalTime.of(4, 59)),
+        Morning(R.string.text_stats_time_morning, LocalTime.of(5, 0) to LocalTime.of(11, 59, 59)),
+        Afternoon(R.string.text_stats_time_afternoon, LocalTime.of(12, 0) to LocalTime.of(16, 59, 59)),
+        Evening(R.string.text_stats_time_evening, LocalTime.of(17, 0) to LocalTime.of(21, 59, 59)),
+        Night(R.string.text_stats_time_late_night, LocalTime.of(22, 0) to LocalTime.of(4, 59, 59)),
     }
 }

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/model/ScreenTimeData.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/model/ScreenTimeData.kt
@@ -1,0 +1,39 @@
+package tv.trakt.trakt.core.profile.sections.screentime.model
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableMap
+import tv.trakt.trakt.resources.R
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.time.Duration
+
+@Immutable
+internal data class ScreenTimeData(
+    val stats: Stats,
+    val dailyHours: ImmutableMap<LocalDate, Duration>,
+    val peakHours: ImmutableMap<PeakHour, Int>,
+) {
+    data class Stats(
+        val totalTime: Duration,
+        val totalTimeChange: Duration,
+        val averagePerDay: Duration,
+        val averagePerDayChange: Duration,
+        val showsTime: Duration,
+        val showsTimeChange: Duration,
+        val moviesTime: Duration,
+        val moviesTimeChange: Duration,
+        val wakingHoursPercent: Int,
+        val wakingHoursPercentChange: Int,
+    )
+
+    enum class PeakHour(
+        @param:StringRes val displayRes: Int,
+        val period: Pair<LocalTime, LocalTime>,
+    ) {
+        Morning(R.string.text_stats_time_morning, LocalTime.of(5, 0) to LocalTime.of(11, 59)),
+        Afternoon(R.string.text_stats_time_afternoon, LocalTime.of(12, 0) to LocalTime.of(16, 59)),
+        Evening(R.string.text_stats_time_evening, LocalTime.of(17, 0) to LocalTime.of(21, 59)),
+        Night(R.string.text_stats_time_late_night, LocalTime.of(22, 0) to LocalTime.of(4, 59)),
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ui/ScreenTimeDailyBreakdownCard.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ui/ScreenTimeDailyBreakdownCard.kt
@@ -1,0 +1,202 @@
+package tv.trakt.trakt.core.profile.sections.screentime.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment.Companion.Bottom
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
+import tv.trakt.trakt.common.helpers.extensions.rememberDurationFormat
+import tv.trakt.trakt.common.ui.theme.colors.Purple200
+import tv.trakt.trakt.common.ui.theme.colors.Purple500
+import tv.trakt.trakt.common.ui.theme.colors.Purple850
+import tv.trakt.trakt.core.profile.sections.screentime.StatWideCardWidth
+import tv.trakt.trakt.core.profile.sections.screentime.usecase.WAKING_HOURS_PER_DAY
+import tv.trakt.trakt.resources.R
+import tv.trakt.trakt.ui.theme.TraktTheme
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+// Bars below this fraction of the tallest day still render a visible stub.
+private const val MIN_BAR_FRACTION = 0.06F
+
+@Composable
+internal fun ScreenTimeDailyBreakdownCard(
+    modifier: Modifier = Modifier,
+    data: ImmutableMap<LocalDate, Duration>,
+    containerColor: Color = TraktTheme.colors.dialogContainer,
+) {
+    val locale = configurationLocale()
+    val today = remember { LocalDate.now() }
+    val days = remember(data) { data.entries.sortedBy { it.key } }
+    val maxMinutes = remember(days) { days.maxOfOrNull { it.value.inWholeMinutes } ?: 0L }
+
+    Column(
+        verticalArrangement = spacedBy(12.dp),
+        modifier = modifier
+            .background(
+                color = containerColor,
+                shape = RoundedCornerShape(16.dp),
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.header_stats_graph_screen_time_daily),
+            style = TraktTheme.typography.cardSubtitle,
+            color = TraktTheme.colors.textSecondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Column(
+            verticalArrangement = spacedBy(4.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1F),
+        ) {
+            Row(
+                verticalAlignment = Bottom,
+                horizontalArrangement = spacedBy(6.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1F),
+            ) {
+                days.forEach { (_, duration) ->
+                    val minutes = duration.inWholeMinutes
+                    val fraction = when {
+                        maxMinutes > 0 -> (minutes.toFloat() / maxMinutes).coerceAtLeast(MIN_BAR_FRACTION)
+                        else -> MIN_BAR_FRACTION
+                    }
+                    Column(
+                        horizontalAlignment = CenterHorizontally,
+                        verticalArrangement = Arrangement.Bottom,
+                        modifier = Modifier
+                            .weight(1F)
+                            .fillMaxHeight(),
+                    ) {
+                        Text(
+                            text = rememberDurationFormat(
+                                duration = minutes,
+                                spaces = false,
+                            ),
+                            style = TraktTheme.typography.cardTitle.copy(fontSize = 8.sp),
+                            color = TraktTheme.colors.textPrimary,
+                            maxLines = 1,
+                            textAlign = TextAlign.Center,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(bottom = 4.dp),
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .fillMaxHeight(fraction)
+                                .background(
+                                    color = barColor(minutes),
+                                    shape = RoundedCornerShape(
+                                        topStart = 6.dp,
+                                        topEnd = 6.dp,
+                                    ),
+                                ),
+                        )
+                    }
+                }
+            }
+
+            Row(
+                horizontalArrangement = spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                days.forEach { (date, _) ->
+                    Text(
+                        text = when (date) {
+                            today -> stringResource(R.string.text_stats_today)
+                            else -> date.dayOfWeek.getDisplayName(TextStyle.SHORT_STANDALONE, locale)
+                        },
+                        style = TraktTheme.typography.cardTitle.copy(fontSize = 8.sp),
+                        color = TraktTheme.colors.textPrimary,
+                        maxLines = 1,
+                        textAlign = TextAlign.Center,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1F),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun configurationLocale(): Locale {
+    val configuration = LocalConfiguration.current
+    return remember(configuration) {
+        configuration.locales.get(0) ?: Locale.getDefault()
+    }
+}
+
+private fun barColor(minutes: Long): Color {
+    val pct = minutes.toFloat() / (WAKING_HOURS_PER_DAY * 60) * 100
+    return when {
+        pct >= 30 -> Purple200
+        pct >= 15 -> Purple500
+        else -> Purple850
+    }
+}
+
+@Preview(widthDp = 320)
+@Composable
+private fun Preview() {
+    val base = LocalDate.now().minusDays(6)
+    val sample = listOf(108L, 145L, 51L, 51L, 51L, 320L, 95L)
+        .mapIndexed { index, mins -> base.plusDays(index.toLong()) to mins.minutes }
+        .toMap()
+        .toImmutableMap()
+
+    TraktTheme {
+        ScreenTimeDailyBreakdownCard(
+            data = sample,
+            modifier = Modifier
+                .width(StatWideCardWidth)
+                .height(156.dp)
+                .padding(16.dp),
+        )
+    }
+}
+
+@Preview(widthDp = 320)
+@Composable
+private fun PreviewEmpty() {
+    TraktTheme {
+        ScreenTimeDailyBreakdownCard(
+            data = emptyMap<LocalDate, Duration>().toImmutableMap(),
+            modifier = Modifier
+                .width(StatWideCardWidth)
+                .height(156.dp)
+                .padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ui/ScreenTimePeakHoursCard.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ui/ScreenTimePeakHoursCard.kt
@@ -1,0 +1,121 @@
+package tv.trakt.trakt.core.profile.sections.screentime.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Arrangement.Absolute.SpaceEvenly
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
+import tv.trakt.trakt.common.ui.theme.colors.Shade800
+import tv.trakt.trakt.core.profile.sections.screentime.StatCardSize
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData.PeakHour
+import tv.trakt.trakt.resources.R
+import tv.trakt.trakt.ui.theme.TraktTheme
+import kotlin.random.Random
+
+@Composable
+internal fun ScreenTimePeakHoursCard(
+    modifier: Modifier = Modifier,
+    data: ImmutableMap<PeakHour, Int>,
+    containerColor: Color = TraktTheme.colors.dialogContainer,
+) {
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .background(
+                color = containerColor,
+                shape = RoundedCornerShape(16.dp),
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.header_stats_graph_peak),
+            style = TraktTheme.typography.cardSubtitle,
+            color = TraktTheme.colors.textSecondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        val total = data.maxOfOrNull { it.value } ?: 0
+        PeakHour.entries.forEach { peakHour ->
+            Row(
+                verticalAlignment = CenterVertically,
+                horizontalArrangement = SpaceEvenly,
+            ) {
+                Text(
+                    text = stringResource(peakHour.displayRes),
+                    style = TraktTheme.typography.cardTitle.copy(
+                        fontSize = 10.sp,
+                    ),
+                    color = TraktTheme.colors.textPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .weight(3F)
+                        .padding(end = 8.dp),
+                )
+
+                LinearProgressIndicator(
+                    progress = {
+                        val current = data[peakHour] ?: 0
+                        when {
+                            total > 0 -> current.toFloat() / total
+                            else -> 0F
+                        }.coerceAtLeast(0.01F)
+                    },
+                    gapSize = 2.dp,
+                    color = TraktTheme.colors.accent,
+                    trackColor = Shade800,
+                    drawStopIndicator = { },
+                    modifier = Modifier.weight(5F),
+                )
+
+                Text(
+                    text = "${data[peakHour] ?: 0}",
+                    style = TraktTheme.typography.cardTitle.copy(
+                        fontSize = 10.sp,
+                    ),
+                    color = TraktTheme.colors.textPrimary,
+                    maxLines = 1,
+                    textAlign = TextAlign.End,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .width(40.dp)
+                        .padding(start = 16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 300)
+@Composable
+private fun ScreenTimePeakHoursCardPreview() {
+    TraktTheme {
+        ScreenTimePeakHoursCard(
+            data = PeakHour.entries
+                .associateWith { Random.nextInt(20) }
+                .toImmutableMap(),
+            modifier = Modifier
+                .height(StatCardSize)
+                .padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ui/ScreenTimeStatCard.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/ui/ScreenTimeStatCard.kt
@@ -1,0 +1,111 @@
+package tv.trakt.trakt.core.profile.sections.screentime.ui
+
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import tv.trakt.trakt.core.profile.sections.screentime.StatCardSize
+import tv.trakt.trakt.ui.theme.TraktTheme
+
+private val cardShape = RoundedCornerShape(16.dp)
+
+@Composable
+internal fun ScreenTimeStatCard(
+    modifier: Modifier = Modifier,
+    value: String,
+    label: String,
+    subtitle: String,
+    subtitleColor: Color = TraktTheme.colors.textSecondary,
+    containerColor: Color = TraktTheme.colors.dialogContainer,
+) {
+    Column(
+        verticalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .background(
+                color = containerColor,
+                shape = cardShape,
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+    ) {
+        Text(
+            text = label,
+            style = TraktTheme.typography.cardSubtitle,
+            color = TraktTheme.colors.textSecondary,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = value,
+            style = TraktTheme.typography.heading3.copy(
+                fontSize = 22.sp,
+                letterSpacing = 0.02.sp,
+            ),
+            color = TraktTheme.colors.textPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = subtitle,
+            style = TraktTheme.typography.meta,
+            color = subtitleColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+internal fun ScreenTimeStatCardSkeleton(modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "infiniteTransition")
+    val shimmerTransition by infiniteTransition
+        .animateColor(
+            initialValue = TraktTheme.colors.skeletonContainer,
+            targetValue = TraktTheme.colors.skeletonShimmer,
+            animationSpec = infiniteRepeatable(
+                animation = tween(1000),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "shimmerTransition",
+        )
+
+    Box(
+        modifier = modifier
+            .background(
+                color = shimmerTransition,
+                shape = cardShape,
+            ),
+    )
+}
+
+@Preview(widthDp = 200)
+@Composable
+private fun ScreenTimeStatCardPreview() {
+    TraktTheme {
+        ScreenTimeStatCard(
+            value = "12h 6m",
+            label = "Total Time",
+            subtitle = "+1h 30m",
+            subtitleColor = Color(0xFF4CAF50),
+            modifier = Modifier
+                .height(StatCardSize)
+                .padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/usecase/GetScreenTimeUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/usecase/GetScreenTimeUseCase.kt
@@ -1,0 +1,248 @@
+package tv.trakt.trakt.core.profile.sections.screentime.usecase
+
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import tv.trakt.trakt.common.core.user.data.remote.history.UserHistoryRemoteDataSource
+import tv.trakt.trakt.common.helpers.extensions.nowLocalDay
+import tv.trakt.trakt.common.helpers.extensions.toInstant
+import tv.trakt.trakt.common.helpers.extensions.toLocalDay
+import tv.trakt.trakt.common.helpers.extensions.toLocalTime
+import tv.trakt.trakt.common.networking.SyncHistoryEpisodeItemDto
+import tv.trakt.trakt.common.networking.SyncHistoryMovieItemDto
+import tv.trakt.trakt.core.profile.sections.screentime.data.local.ScreenTimeLocalDataSource
+import tv.trakt.trakt.core.profile.sections.screentime.model.ScreenTimeData
+import java.time.LocalDate
+import java.time.ZoneOffset.UTC
+import kotlin.math.roundToInt
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toKotlinInstant
+
+internal const val WAKING_HOURS_PER_DAY = 16
+
+internal class GetScreenTimeUseCase(
+    private val remoteSource: UserHistoryRemoteDataSource,
+    private val localDataSource: ScreenTimeLocalDataSource,
+) {
+    suspend fun getLocalScreenTimeData(): ScreenTimeData? {
+        return localDataSource.getData()
+    }
+
+    suspend fun getScreenTimeData(): ScreenTimeData {
+        val startLocal = nowLocalDay().minusDays(15).atStartOfDay()
+        val endLocal = nowLocalDay().plusDays(1).atStartOfDay()
+
+        return coroutineScope {
+            val from = startLocal.toInstant(UTC).toKotlinInstant()
+            val to = endLocal.toInstant(UTC).toKotlinInstant()
+
+            val remoteEpisodesAsync = async {
+                remoteSource.getEpisodesHistory(
+                    limit = 500,
+                    filters = null,
+                    from = from,
+                    to = to,
+                )
+            }
+
+            val remoteMoviesAsync = async {
+                remoteSource.getMoviesHistory(
+                    limit = 500,
+                    filters = null,
+                    from = from,
+                    to = to,
+                )
+            }
+
+            val remoteEpisodes = remoteEpisodesAsync.await()
+            val remoteMovies = remoteMoviesAsync.await()
+
+            val offsetCurrent = nowLocalDay().minusDays(6)
+            val offsetPrevious = offsetCurrent.minusDays(7)
+
+            val episodesLast7Days = remoteEpisodes.filter { it.watchedAt.toInstant().toLocalDay() >= offsetCurrent }
+            val moviesLast7Days = remoteMovies.filter { it.watchedAt.toInstant().toLocalDay() >= offsetCurrent }
+
+            val episodesPrevious7Days = remoteEpisodes.filter {
+                val watchedDay = it.watchedAt.toInstant().toLocalDay()
+                watchedDay in offsetPrevious..<offsetCurrent
+            }
+            val moviesPrevious7Days = remoteMovies.filter {
+                val watchedDay = it.watchedAt.toInstant().toLocalDay()
+                watchedDay in offsetPrevious..<offsetCurrent
+            }
+
+            val (totalTime, totalTimePrevious) = getTotalTime(
+                episodes = episodesLast7Days,
+                previousEpisodes = episodesPrevious7Days,
+                movies = moviesLast7Days,
+                previousMovies = moviesPrevious7Days,
+            )
+
+            val (showsTime, showsPreviousTime) = getTotalShowsTime(
+                episodes = episodesLast7Days,
+                previousEpisodes = episodesPrevious7Days,
+            )
+
+            val (moviesTime, moviesPreviousTime) = getTotalMoviesTime(
+                movies = moviesLast7Days,
+                previousMovies = moviesPrevious7Days,
+            )
+
+            val (averagePerDay, averagePerDayPrevious) = getTotalAvgTime(
+                totalTime = totalTime,
+                totalPreviousTime = totalTimePrevious,
+                episodes = episodesLast7Days,
+                previousEpisodes = episodesPrevious7Days,
+                movies = moviesLast7Days,
+                previousMovies = moviesPrevious7Days,
+            )
+
+            val (wakingHoursPercent, wakingHoursPercentChange) = getWakingHoursPercent(
+                totalTime = totalTime,
+                totalPreviousTime = totalTimePrevious,
+            )
+
+            return@coroutineScope ScreenTimeData(
+                stats = ScreenTimeData.Stats(
+                    totalTime = totalTime,
+                    totalTimeChange = totalTime - totalTimePrevious,
+                    averagePerDay = averagePerDay,
+                    averagePerDayChange = averagePerDay - averagePerDayPrevious,
+                    showsTime = showsTime,
+                    showsTimeChange = showsTime - showsPreviousTime,
+                    moviesTime = moviesTime,
+                    moviesTimeChange = moviesTime - moviesPreviousTime,
+                    wakingHoursPercent = wakingHoursPercent,
+                    wakingHoursPercentChange = wakingHoursPercentChange,
+                ),
+                dailyHours = getDailyHours(
+                    rangeStart = offsetCurrent,
+                    episodes = episodesLast7Days,
+                    movies = moviesLast7Days,
+                ),
+                peakHours = getPeakHours(
+                    episodes = episodesLast7Days,
+                    movies = moviesLast7Days,
+                ),
+            )
+        }.also {
+            localDataSource.setData(it)
+        }
+    }
+
+    private fun getDailyHours(
+        rangeStart: LocalDate,
+        episodes: List<SyncHistoryEpisodeItemDto>,
+        movies: List<SyncHistoryMovieItemDto>,
+    ): ImmutableMap<LocalDate, Duration> {
+        val minutesPerDay = mutableMapOf<LocalDate, Int>()
+        episodes.forEach { item ->
+            val day = item.watchedAt.toInstant().toLocalDay()
+            minutesPerDay[day] = (minutesPerDay[day] ?: 0) + (item.episode.runtime ?: 0)
+        }
+        movies.forEach { item ->
+            val day = item.watchedAt.toInstant().toLocalDay()
+            minutesPerDay[day] = (minutesPerDay[day] ?: 0) + (item.movie.runtime ?: 0)
+        }
+
+        return (0L..6L)
+            .associate { offset ->
+                val day = rangeStart.plusDays(offset)
+                day to (minutesPerDay[day] ?: 0).minutes
+            }
+            .toImmutableMap()
+    }
+
+    private fun getPeakHours(
+        episodes: List<SyncHistoryEpisodeItemDto>,
+        movies: List<SyncHistoryMovieItemDto>,
+    ): ImmutableMap<ScreenTimeData.PeakHour, Int> {
+        val watchedTimes = episodes.map { it.watchedAt.toInstant().toLocalTime() } +
+            movies.map { it.watchedAt.toInstant().toLocalTime() }
+
+        return ScreenTimeData.PeakHour.entries
+            .associateWith { peakHour ->
+                watchedTimes.count { time ->
+                    val (start, end) = peakHour.period
+                    when {
+                        start <= end -> time in start..end
+                        else -> time >= start || time <= end
+                    }
+                }
+            }
+            .toImmutableMap()
+    }
+
+    private fun getWakingHoursPercent(
+        totalTime: Duration,
+        totalPreviousTime: Duration,
+    ): Pair<Int, Int> {
+        val wakingMinutes = WAKING_HOURS_PER_DAY * 7 * 60
+        val thisPercent = (totalTime.inWholeMinutes.toDouble() / wakingMinutes * 100).roundToInt()
+        val previousPercent = (totalPreviousTime.inWholeMinutes.toDouble() / wakingMinutes * 100).roundToInt()
+        return thisPercent to (thisPercent - previousPercent)
+    }
+
+    private fun getTotalTime(
+        episodes: List<SyncHistoryEpisodeItemDto>,
+        previousEpisodes: List<SyncHistoryEpisodeItemDto>,
+        movies: List<SyncHistoryMovieItemDto>,
+        previousMovies: List<SyncHistoryMovieItemDto>,
+    ): Pair<Duration, Duration> {
+        val totalTime =
+            episodes.sumOf { it.episode.runtime ?: 0 } +
+                movies.sumOf { it.movie.runtime ?: 0 }
+
+        val totalPreviousTime = previousEpisodes.sumOf { it.episode.runtime ?: 0 } +
+            previousMovies.sumOf { it.movie.runtime ?: 0 }
+
+        return totalTime.minutes to totalPreviousTime.minutes
+    }
+
+    private fun getTotalAvgTime(
+        totalTime: Duration,
+        totalPreviousTime: Duration,
+        episodes: List<SyncHistoryEpisodeItemDto>,
+        previousEpisodes: List<SyncHistoryEpisodeItemDto>,
+        movies: List<SyncHistoryMovieItemDto>,
+        previousMovies: List<SyncHistoryMovieItemDto>,
+    ): Pair<Duration, Duration> {
+        val activeDays = activeDayCount(episodes, movies)
+        val activeDaysPrevious = activeDayCount(previousEpisodes, previousMovies)
+
+        val average = if (activeDays > 0) totalTime / activeDays else Duration.ZERO
+        val averagePrevious = if (activeDaysPrevious > 0) totalPreviousTime / activeDaysPrevious else Duration.ZERO
+
+        return average to averagePrevious
+    }
+
+    private fun activeDayCount(
+        episodes: List<SyncHistoryEpisodeItemDto>,
+        movies: List<SyncHistoryMovieItemDto>,
+    ): Int {
+        val days = episodes.mapTo(mutableSetOf()) { it.watchedAt.toInstant().toLocalDay() }
+        movies.mapTo(days) { it.watchedAt.toInstant().toLocalDay() }
+        return days.size
+    }
+
+    private fun getTotalShowsTime(
+        episodes: List<SyncHistoryEpisodeItemDto>,
+        previousEpisodes: List<SyncHistoryEpisodeItemDto>,
+    ): Pair<Duration, Duration> {
+        val showsTime = episodes.sumOf { it.episode.runtime ?: 0 }
+        val showsPreviousTime = previousEpisodes.sumOf { it.episode.runtime ?: 0 }
+        return showsTime.minutes to showsPreviousTime.minutes
+    }
+
+    private fun getTotalMoviesTime(
+        movies: List<SyncHistoryMovieItemDto>,
+        previousMovies: List<SyncHistoryMovieItemDto>,
+    ): Pair<Duration, Duration> {
+        val moviesTime = movies.sumOf { it.movie.runtime ?: 0 }
+        val moviesPreviousTime = previousMovies.sumOf { it.movie.runtime ?: 0 }
+        return moviesTime.minutes to moviesPreviousTime.minutes
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/usecase/GetScreenTimeUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/screentime/usecase/GetScreenTimeUseCase.kt
@@ -31,7 +31,7 @@ internal class GetScreenTimeUseCase(
     }
 
     suspend fun getScreenTimeData(): ScreenTimeData {
-        val startLocal = nowLocalDay().minusDays(15).atStartOfDay()
+        val startLocal = nowLocalDay().minusDays(14).atStartOfDay()
         val endLocal = nowLocalDay().plusDays(1).atStartOfDay()
 
         return coroutineScope {

--- a/app/src/main/java/tv/trakt/trakt/core/user/usecases/LogoutUserUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/user/usecases/LogoutUserUseCase.kt
@@ -31,6 +31,7 @@ import tv.trakt.trakt.core.profile.sections.activity.data.local.ratings.ProfileR
 import tv.trakt.trakt.core.profile.sections.progress.data.local.completed.ProgressCompletedLocalDataSource
 import tv.trakt.trakt.core.profile.sections.progress.data.local.dropped.ProgressDroppedLocalDataSource
 import tv.trakt.trakt.core.profile.sections.progress.data.local.watching.ProgressWatchingLocalDataSource
+import tv.trakt.trakt.core.profile.sections.screentime.data.local.ScreenTimeLocalDataSource
 import tv.trakt.trakt.core.settings.features.younify.data.remote.YounifyRemoteDataSource
 import tv.trakt.trakt.core.user.data.local.UserListsLocalDataSource
 import tv.trakt.trakt.core.user.data.local.UserProgressLocalDataSource
@@ -75,6 +76,7 @@ internal class LogoutUserUseCase(
     private val localProfileCompleted: ProgressCompletedLocalDataSource,
     private val localProfileWatching: ProgressWatchingLocalDataSource,
     private val localProfileDropped: ProgressDroppedLocalDataSource,
+    private val localScreenTime: ScreenTimeLocalDataSource,
     private val localProfileRatings: ProfileRatingsLocalDataSource,
     private val localProfileComments: ProfileCommentsLocalDataSource,
     private val appReviewUseCase: RequestAppReviewUseCase,
@@ -119,6 +121,7 @@ internal class LogoutUserUseCase(
         localProfileCompleted.clear()
         localProfileWatching.clear()
         localProfileDropped.clear()
+        localScreenTime.clear()
         localProfileRatings.clear()
         localProfileComments.clear()
 

--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileScreen.kt
@@ -361,6 +361,21 @@ private fun LazyListScope.userProfilePublicContent(
     }
 
     item {
+        UserProfileFavoritesView(
+            viewModel = koinViewModel(
+                parameters = { parametersOf(state.user.ids.trakt) },
+            ),
+            headerPadding = sectionPadding,
+            contentPadding = sectionPadding,
+            onShowClick = onNavigateToShow,
+            onMovieClick = onNavigateToMovie,
+            onMoreClick = { onNavigateToAllFavorites(state.user.ids.trakt) },
+            modifier = Modifier
+                .padding(bottom = TraktTheme.spacing.mainSectionVerticalSpace),
+        )
+    }
+
+    item {
         UserProfileHistoryView(
             viewModel = koinViewModel(
                 parameters = { parametersOf(state.user.ids.trakt) },
@@ -371,21 +386,6 @@ private fun LazyListScope.userProfilePublicContent(
             onEpisodeClick = onNavigateToEpisode,
             onMovieClick = onNavigateToMovie,
             onMoreClick = { onNavigateToAllHistory(state.user.ids.trakt) },
-            modifier = Modifier
-                .padding(bottom = TraktTheme.spacing.mainSectionVerticalSpace),
-        )
-    }
-
-    item {
-        UserProfileFavoritesView(
-            viewModel = koinViewModel(
-                parameters = { parametersOf(state.user.ids.trakt) },
-            ),
-            headerPadding = sectionPadding,
-            contentPadding = sectionPadding,
-            onShowClick = onNavigateToShow,
-            onMovieClick = onNavigateToMovie,
-            onMoreClick = { onNavigateToAllFavorites(state.user.ids.trakt) },
             modifier = Modifier
                 .padding(bottom = TraktTheme.spacing.mainSectionVerticalSpace),
         )

--- a/app/src/main/java/tv/trakt/trakt/helpers/collapsing/model/CollapsingKey.kt
+++ b/app/src/main/java/tv/trakt/trakt/helpers/collapsing/model/CollapsingKey.kt
@@ -92,6 +92,7 @@ internal enum class CollapsingKey(
     PROFILE_PROGRESS("key_profile_progress"),
     PROFILE_LIBRARY("key_profile_library"),
     PROFILE_SOCIAL("key_profile_social"),
+    PROFILE_SCREEN_TIME("key_profile_screen_time"),
 
     // User Profile Screen
     USER_PROFILE_HISTORY("key_user_profile_history"),

--- a/common/src/main/java/tv/trakt/trakt/common/helpers/extensions/ComposeExtensions.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/helpers/extensions/ComposeExtensions.kt
@@ -14,6 +14,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 )
 annotation class DevicePreview
 
+@Preview(
+    device = "id:pixel_7",
+    showBackground = false,
+    backgroundColor = 0xFF212427,
+    locale = "us",
+)
+annotation class DeviceSheetPreview
+
 fun MutableStateFlow<*>.isNotNull(): Boolean {
     return this.value != null
 }

--- a/common/src/main/java/tv/trakt/trakt/common/helpers/extensions/DateExtensions.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/helpers/extensions/DateExtensions.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZoneOffset.UTC
@@ -124,6 +125,8 @@ fun ZonedDateTime.toLocal(): ZonedDateTime = this.withZoneSameInstant(ZoneId.sys
 fun Instant.toLocal(): ZonedDateTime = this.atZone(ZoneId.systemDefault())
 
 fun Instant.toLocalDay(): LocalDate = this.atZone(ZoneId.systemDefault()).toLocalDate()
+
+fun Instant.toLocalTime(): LocalTime = this.atZone(ZoneId.systemDefault()).toLocalTime()
 
 fun LocalDate.isTodayOrBefore(): Boolean {
     val today = LocalDate.now()

--- a/common/src/main/java/tv/trakt/trakt/common/helpers/extensions/StringExtensions.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/helpers/extensions/StringExtensions.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight.Companion.W500
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import java.util.Locale
+import kotlin.math.abs
 
 /**
  * Formats an integer into a compact string representation using thousands (e.g., 1.2K for 1200).
@@ -54,9 +55,10 @@ fun rememberThousandsFormat(count: Int): String {
 fun Long.durationFormat(
     locale: Locale = AppCompatDelegate.getApplicationLocales().get(0) ?: Locale.getDefault(),
 ): String {
-    val days = this / (60 * 24)
-    val hours = (this % (60 * 24)) / 60
-    val minutes = this % 60
+    val magnitude = abs(this)
+    val days = magnitude / (60 * 24)
+    val hours = (magnitude % (60 * 24)) / 60
+    val minutes = magnitude % 60
 
     val measures = mutableListOf<Measure>()
     if (days > 0) {
@@ -70,7 +72,8 @@ fun Long.durationFormat(
     }
 
     val format = MeasureFormat.getInstance(locale, FormatWidth.NARROW)
-    return format.formatMeasures(*measures.toTypedArray()).capitalize()
+    val formatted = format.formatMeasures(*measures.toTypedArray()).capitalize()
+    return if (this < 0) "-$formatted" else formatted
 }
 
 /**
@@ -78,12 +81,22 @@ fun Long.durationFormat(
  * If the duration is null, it returns "N/A".
  */
 @Composable
-fun rememberDurationFormat(duration: Long?): String {
-    if (duration == null) return "N/A"
+fun rememberDurationFormat(
+    duration: Long?,
+    spaces: Boolean = true,
+): String {
+    if (duration == null) {
+        return "N/A"
+    }
+
     val configuration = LocalConfiguration.current
     return remember(duration, configuration) {
         val configurationLocale = AppCompatDelegate.getApplicationLocales().get(0) ?: Locale.getDefault()
-        duration.durationFormat(configurationLocale)
+        val format = duration.durationFormat(configurationLocale)
+        when {
+            spaces -> format
+            else -> format.replace(" ", "")
+        }
     }
 }
 

--- a/common/src/main/java/tv/trakt/trakt/common/ui/theme/colors/Colorography.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/ui/theme/colors/Colorography.kt
@@ -43,6 +43,7 @@ val Purple500 = Color(0xFF9F42C6)
 val Purple600 = Color(0xFF913CB4)
 val Purple700 = Color(0xFF712F8D)
 val Purple800 = Color(0xFF57246D)
+val Purple850 = Color(0xFF431D53)
 val Purple900 = Color(0xFF431C53)
 val Purple920 = Color(0xFF3A1740)
 
@@ -76,6 +77,9 @@ val Orange300 = Color(0xffff9458)
 val Orange400 = Color(0xFFff7f38)
 val Orange500 = Color(0xFFFF5f06)
 val Orange900 = Color(0xFF6b2803)
+
+// Yellow
+val Yellow500 = Color(0xFFf5b301)
 
 // Blue
 val Blue50 = Color(0xFFE6F6FF)


### PR DESCRIPTION
Adds a Screen Time section to the user profile, surfacing watch-time analytics derived from the last 7 days of viewing history (with the prior 7 days for change comparison).

<img height="800" alt="image" src="https://github.com/user-attachments/assets/ddf9b133-889d-41f7-a9a8-7240e614d7df" />

<img height="800" alt="image" src="https://github.com/user-attachments/assets/2f32c46d-8d79-4a0a-ad62-2600626d1bda" />
