### PR TITLE
fix(common): introduce episode air buffer for earlier availability

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/calendar/ui/CalendarEpisodeItemView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/calendar/ui/CalendarEpisodeItemView.kt
@@ -52,10 +52,7 @@ internal fun CalendarEpisodeItemView(
     onCheckLongClick: () -> Unit = {},
     onRemoveClick: () -> Unit = {},
 ) {
-    val isReleased = remember(item.releasedAt) {
-        val releasedAt = item.releasedAt
-        releasedAt != null && releasedAt.isBefore(nowUtcInstant())
-    }
+    val isReleased = item.episode.rememberReleased()
 
     HorizontalMediaCard(
         modifier = modifier,

--- a/app/src/main/java/tv/trakt/trakt/core/calendar/ui/CalendarEpisodeItemView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/calendar/ui/CalendarEpisodeItemView.kt
@@ -52,8 +52,6 @@ internal fun CalendarEpisodeItemView(
     onCheckLongClick: () -> Unit = {},
     onRemoveClick: () -> Unit = {},
 ) {
-    val isReleased = item.episode.rememberReleased()
-
     HorizontalMediaCard(
         modifier = modifier,
         title = "",
@@ -146,7 +144,7 @@ internal fun CalendarEpisodeItemView(
                     )
                 }
 
-                if (isReleased && !item.isFullSeason) {
+                if (item.episode.rememberReleased() && !item.isFullSeason) {
                     Box(
                         contentAlignment = Alignment.Center,
                         modifier = Modifier

--- a/common/src/main/java/tv/trakt/trakt/common/model/Episode.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/model/Episode.kt
@@ -22,6 +22,11 @@ import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
+// Grace window before an episode's air date during which it is already
+// considered aired. Absorbs timezone/scheduling skew so check-ins and
+// other aired-gated UI don't lag behind the actual broadcast.
+private const val AIR_BUFFER_HOURS = 24L
+
 @Immutable
 @Serializable
 data class Episode(
@@ -44,13 +49,6 @@ data class Episode(
     @Serializable(InstantSerializer::class)
     private val effectiveReleaseDate: Instant?,
 ) {
-    companion object {
-        // Grace window before an episode's air date during which it is already
-        // considered aired. Absorbs timezone/scheduling skew so check-ins and
-        // other aired-gated UI don't lag behind the actual broadcast.
-        private const val AIR_BUFFER_HOURS = 24L
-    }
-
     val releasedAt: Instant?
         get() = effectiveReleaseDate ?: firstAired
 

--- a/common/src/main/java/tv/trakt/trakt/common/model/Episode.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/model/Episode.kt
@@ -18,6 +18,7 @@ import tv.trakt.trakt.common.networking.EpisodeLikesDto
 import tv.trakt.trakt.common.networking.LastEpisodeDto
 import tv.trakt.trakt.resources.R
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
@@ -43,13 +44,20 @@ data class Episode(
     @Serializable(InstantSerializer::class)
     private val effectiveReleaseDate: Instant?,
 ) {
-    companion object
+    companion object {
+        // Grace window before an episode's air date during which it is already
+        // considered aired. Absorbs timezone/scheduling skew so check-ins and
+        // other aired-gated UI don't lag behind the actual broadcast.
+        private const val AIR_BUFFER_HOURS = 24L
+    }
 
     val releasedAt: Instant?
         get() = effectiveReleaseDate ?: firstAired
 
     val isReleased: Boolean
-        get() = releasedAt?.let { !it.isAfter(nowUtcInstant()) } ?: false
+        get() = releasedAt?.let {
+            !it.isAfter(nowUtcInstant().plus(AIR_BUFFER_HOURS, ChronoUnit.HOURS))
+        } ?: false
 
     val seasonEpisode: SeasonEpisode
         get() = SeasonEpisode(

--- a/common/src/main/java/tv/trakt/trakt/common/model/Episode.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/model/Episode.kt
@@ -18,14 +18,15 @@ import tv.trakt.trakt.common.networking.EpisodeLikesDto
 import tv.trakt.trakt.common.networking.LastEpisodeDto
 import tv.trakt.trakt.resources.R
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 // Grace window before an episode's air date during which it is already
 // considered aired. Absorbs timezone/scheduling skew so check-ins and
 // other aired-gated UI don't lag behind the actual broadcast.
-private const val AIR_BUFFER_HOURS = 24L
+private val AIR_DATE_BUFFER = 24.hours.toJavaDuration()
 
 @Immutable
 @Serializable
@@ -54,7 +55,7 @@ data class Episode(
 
     val isReleased: Boolean
         get() = releasedAt?.let {
-            !it.isAfter(nowUtcInstant().plus(AIR_BUFFER_HOURS, ChronoUnit.HOURS))
+            !it.isAfter(nowUtcInstant().plus(AIR_DATE_BUFFER))
         } ?: false
 
     val seasonEpisode: SeasonEpisode


### PR DESCRIPTION
## What

Aligns the android client with trakt-web (source of truth), which now applies a
24h grace buffer to the episode `hasAired` check
([trakt/trakt-web#2918](https://github.com/trakt/trakt-web/pull/2918)). An
episode airing within the next 24h is already treated as released, absorbing
timezone/scheduling skew so check-ins and other aired-gated UI do not lag
behind the actual broadcast.

Generated from a `/compare-clients` parity report (web ref `46341b3`).

## Changes

- `common/.../model/Episode.kt`
  - `Episode.isReleased` now compares `releasedAt` against a 24h-ahead cutoff
    (`now + AIR_BUFFER_HOURS`) instead of `now`. Shows and movies keep the
    strict comparison, matching web's episode-only buffer.
  - Added the `AIR_BUFFER_HOURS` constant with a short rationale comment.
- `app/.../core/calendar/ui/CalendarEpisodeItemView.kt`
  - Replaced the local strict `releasedAt.isBefore(now)` check with
    `item.episode.isReleased`, so the calendar item inherits the same buffered
    window instead of recomputing a stricter one.

The `effectiveReleaseDate ?: firstAired` resolution and the movie `status`
bypass already matched web and are unchanged.

## Verification

- `./gradlew :common:compilePlaystoreDebugKotlin` - PASS (Episode.kt compiles).
- `:app:compilePlaystoreDebugKotlin` could not be run in this environment: the
  app packaging pipeline requires Firebase / `google-services.json` secrets that
  are not present in the CI-less worktree. The failures were entirely in the
  Google Services / Crashlytics resource tasks, never in Kotlin compilation. The
  `CalendarEpisodeItemView.kt` change is a one-line swap to an existing public
  `Episode.isReleased` property.

Please run the CI build to confirm the app module.