### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/i18n_sync.yml
+++ b/.github/workflows/i18n_sync.yml
@@ -29,7 +29,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/.github/workflows/i18n_values_sync.yml
+++ b/.github/workflows/i18n_values_sync.yml
@@ -25,7 +25,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/openapi_sync.yml
+++ b/.github/workflows/openapi_sync.yml
@@ -24,7 +24,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.generate-token.outputs.token }}
 


### PR DESCRIPTION
Bumps `actions/checkout` from v4 to v5 across all workflows.

v4 pins Node 20, now deprecated on GitHub-hosted runners and force-run on Node 24. v5 targets Node 24 natively. No behavior change.

Files touched:
- `.github/workflows/openapi_sync.yml`
- `.github/workflows/i18n_sync.yml`
- `.github/workflows/i18n_values_sync.yml`