### PR TITLE
Remove uppercase transformation for display name and about

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/checkin/data/service/CheckInService.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/checkin/data/service/CheckInService.kt
@@ -38,7 +38,6 @@ import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
 import tv.trakt.trakt.common.helpers.extensions.recordError
 import tv.trakt.trakt.common.helpers.extensions.rethrowCancellation
 import tv.trakt.trakt.common.helpers.extensions.toLocal
-import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
 import tv.trakt.trakt.common.model.MediaType
 import tv.trakt.trakt.common.model.toTraktId
 import tv.trakt.trakt.common.ui.theme.colors.Purple500
@@ -162,7 +161,7 @@ internal class CheckInService : Service() {
             .Builder(applicationContext, TraktNotificationChannel.CHECK_IN.id)
             .setForegroundServiceBehavior(FOREGROUND_SERVICE_IMMEDIATE)
             .setSmallIcon(R.drawable.ic_trakt_icon_notification)
-            .setSubText(getString(R.string.button_text_checkin).uppercaseWords())
+            .setSubText(getString(R.string.button_text_checkin))
             .setContentTitle(data.title)
             .setContentText("$endsAtText ($contentText)")
             .setShowWhen(false)

--- a/app/src/main/java/tv/trakt/trakt/core/checkin/ui/CheckInView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/checkin/ui/CheckInView.kt
@@ -262,7 +262,7 @@ private fun ExpandedView(
                     .padding(vertical = 2.dp),
             ) {
                 Text(
-                    text = stringResource(R.string.button_text_checkin).uppercaseWords(),
+                    text = stringResource(R.string.button_text_checkin),
                     color = TraktTheme.colors.textPrimary,
                     style = TraktTheme.typography.cardTitle.copy(
                         fontWeight = W400,

--- a/app/src/main/java/tv/trakt/trakt/core/settings/SettingsScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/settings/SettingsScreen.kt
@@ -78,7 +78,6 @@ import tv.trakt.trakt.LocalSnackbarState
 import tv.trakt.trakt.common.Config
 import tv.trakt.trakt.common.helpers.LoadingState.Done
 import tv.trakt.trakt.common.helpers.extensions.onClick
-import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
 import tv.trakt.trakt.common.helpers.preview.PreviewData
 import tv.trakt.trakt.common.model.User
 import tv.trakt.trakt.common.ui.composables.FilmProgressIndicator

--- a/app/src/main/java/tv/trakt/trakt/core/settings/SettingsScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/settings/SettingsScreen.kt
@@ -410,7 +410,7 @@ private fun SettingsAccount(
         }
 
         SettingsValueField(
-            text = stringResource(R.string.text_display_name).uppercaseWords(),
+            text = stringResource(R.string.text_display_name),
             value = state.user?.name,
             enabled = !state.logoutLoading.isLoading && !state.accountLoading.isLoading,
             onClick = {
@@ -428,7 +428,7 @@ private fun SettingsAccount(
         )
 
         SettingsValueField(
-            text = stringResource(R.string.text_about).uppercaseWords(),
+            text = stringResource(R.string.text_about),
             value = state.user?.about,
             enabled = !state.logoutLoading.isLoading && !state.accountLoading.isLoading,
             onClick = {
@@ -462,7 +462,7 @@ private fun SettingsAccount(
 
     SingleInputSheet(
         active = displayNameSheet != null,
-        title = stringResource(R.string.text_display_name).uppercaseWords(),
+        title = stringResource(R.string.text_display_name),
         description = stringResource(R.string.input_prompt_display_name),
         initialInput = displayNameSheet,
         nullable = true,
@@ -494,7 +494,7 @@ private fun SettingsAccount(
 
     SingleInputSheet(
         active = aboutSheet != null,
-        title = stringResource(R.string.text_about).uppercaseWords(),
+        title = stringResource(R.string.text_about),
         description = stringResource(R.string.input_prompt_about),
         initialInput = aboutSheet,
         nullable = true,

--- a/app/src/main/java/tv/trakt/trakt/ui/components/dateselection/DateSelectionView.kt
+++ b/app/src/main/java/tv/trakt/trakt/ui/components/dateselection/DateSelectionView.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
 import tv.trakt.trakt.resources.R
 import tv.trakt.trakt.ui.components.buttons.GhostButton
 import tv.trakt.trakt.ui.components.notifications.NotificationsRationaleSheet
@@ -185,7 +184,7 @@ private fun ActionButtons(
     ) {
         if (nowWatchingVisible) {
             GhostButton(
-                text = stringResource(R.string.button_text_checkin).uppercaseWords(),
+                text = stringResource(R.string.button_text_checkin),
                 icon = painterResource(R.drawable.ic_eye),
                 iconSize = 22.dp,
                 iconSpace = 16.dp,


### PR DESCRIPTION
Preserve the capitalization defined by each locale instead of applying uppercaseWords() at runtime.

For example, the pt-PT translations “Nome de apresentação” and “Sobre mim” were incorrectly displayed as “Nome De Apresentação” and “Sobre Mim”. Capitalization should remain consistent with the Crowdin translations and each language's conventions.