### PR TITLE
fix(app): grant private profile access and hide self actions

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileScreen.kt
@@ -269,6 +269,7 @@ private fun UserProfileContent(
             item {
                 TitleBar(
                     user = state.user,
+                    isCurrentUser = state.isCurrentUser,
                     userBlocked = state.userBlocked,
                     userFollowing = state.userFollowing,
                     onBack = onNavigateBack,
@@ -279,17 +280,14 @@ private fun UserProfileContent(
                 )
             }
 
-            if (state.user.isPrivate) {
-                userProfilePrivateContent(
-                    state = state,
-                    windowClass = windowClass,
-                    onToggleFollowRequest = onToggleFollowRequest,
-                )
-            } else {
-                userProfilePublicContent(
+            when (state.access) {
+                UserProfileState.Access.Checking,
+                UserProfileState.Access.Granted,
+                -> userProfilePublicContent(
                     state = state,
                     windowClass = windowClass,
                     sectionPadding = sectionPadding,
+                    accessChecking = state.access == UserProfileState.Access.Checking,
                     onToggleFollowRequest = onToggleFollowRequest,
                     onNavigateToShow = onNavigateToShow,
                     onNavigateToEpisode = onNavigateToEpisode,
@@ -300,6 +298,11 @@ private fun UserProfileContent(
                     onNavigateToList = onNavigateToList,
                     onNavigateToUser = onNavigateToUser,
                 )
+                UserProfileState.Access.Denied -> userProfilePrivateContent(
+                    state = state,
+                    windowClass = windowClass,
+                    onToggleFollowRequest = onToggleFollowRequest,
+                )
             }
         }
     }
@@ -309,6 +312,7 @@ private fun LazyListScope.userProfilePublicContent(
     state: UserProfileState,
     windowClass: WindowSizeClass,
     sectionPadding: PaddingValues,
+    accessChecking: Boolean,
     onToggleFollowRequest: (approved: Boolean) -> Unit,
     onNavigateToShow: (Show) -> Unit,
     onNavigateToEpisode: (Show, Episode) -> Unit,
@@ -319,9 +323,9 @@ private fun LazyListScope.userProfilePublicContent(
     onNavigateToList: (CustomList) -> Unit,
     onNavigateToUser: (User) -> Unit,
 ) {
-    item {
+    item(key = "follow-request") {
         FollowRequestView(
-            visible = state.userRequest.request != null,
+            visible = !accessChecking && state.userRequest.request != null,
             request = state.userRequest.request,
             loading = state.userRequest.loading,
             onApproveClick = { onToggleFollowRequest(true) },
@@ -333,13 +337,13 @@ private fun LazyListScope.userProfilePublicContent(
     }
 
     if (state.user.isAnyVip) {
-        item {
+        item(key = "profile-stats") {
             ProfileStatsCard(
-                loading = state.monthStats?.loading ?: true,
+                loading = accessChecking || state.monthStats?.loading ?: true,
                 user = state.user,
                 stats = state.monthStats?.stats,
                 showAllStats = false,
-                containerImage = state.monthStats?.backgroundUrl,
+                containerImage = state.monthStats?.backgroundUrl.takeUnless { accessChecking },
                 modifier = Modifier
                     .fillMaxWidth(
                         when {
@@ -358,8 +362,8 @@ private fun LazyListScope.userProfilePublicContent(
         }
     }
 
-    if (!state.user.about.isNullOrBlank()) {
-        item {
+    item(key = "about") {
+        if (!accessChecking && !state.user.about.isNullOrBlank()) {
             var expanded by rememberSaveable { mutableStateOf(false) }
 
             Column(
@@ -394,11 +398,14 @@ private fun LazyListScope.userProfilePublicContent(
         }
     }
 
-    item {
+    item(key = "favorites") {
         UserProfileFavoritesView(
-            viewModel = koinViewModel(
-                parameters = { parametersOf(state.user.ids.trakt) },
-            ),
+            viewModel = when {
+                accessChecking -> null
+                else -> koinViewModel(
+                    parameters = { parametersOf(state.user.ids.trakt) },
+                )
+            },
             headerPadding = sectionPadding,
             contentPadding = sectionPadding,
             onShowClick = onNavigateToShow,
@@ -409,11 +416,14 @@ private fun LazyListScope.userProfilePublicContent(
         )
     }
 
-    item {
+    item(key = "history") {
         UserProfileHistoryView(
-            viewModel = koinViewModel(
-                parameters = { parametersOf(state.user.ids.trakt) },
-            ),
+            viewModel = when {
+                accessChecking -> null
+                else -> koinViewModel(
+                    parameters = { parametersOf(state.user.ids.trakt) },
+                )
+            },
             headerPadding = sectionPadding,
             contentPadding = sectionPadding,
             onShowClick = onNavigateToShow,
@@ -425,11 +435,14 @@ private fun LazyListScope.userProfilePublicContent(
         )
     }
 
-    item {
+    item(key = "lists") {
         UserProfileListsView(
-            viewModel = koinViewModel(
-                parameters = { parametersOf(state.user.ids.trakt) },
-            ),
+            viewModel = when {
+                accessChecking -> null
+                else -> koinViewModel(
+                    parameters = { parametersOf(state.user.ids.trakt) },
+                )
+            },
             headerPadding = sectionPadding,
             contentPadding = sectionPadding,
             onListClick = onNavigateToList,
@@ -439,11 +452,14 @@ private fun LazyListScope.userProfilePublicContent(
         )
     }
 
-    item {
+    item(key = "social") {
         UserProfileSocialView(
-            viewModel = koinViewModel(
-                parameters = { parametersOf(state.user.ids.trakt) },
-            ),
+            viewModel = when {
+                accessChecking -> null
+                else -> koinViewModel(
+                    parameters = { parametersOf(state.user.ids.trakt) },
+                )
+            },
             headerPadding = sectionPadding,
             contentPadding = sectionPadding,
             onUserClick = onNavigateToUser,
@@ -516,6 +532,7 @@ private fun LazyListScope.userProfilePrivateContent(
 @Composable
 private fun TitleBar(
     user: User?,
+    isCurrentUser: Boolean = false,
     userBlocked: UserProfileState.BlockedState?,
     userFollowing: UserProfileState.FollowingState?,
     modifier: Modifier = Modifier,
@@ -629,7 +646,7 @@ private fun TitleBar(
             }
         }
 
-        if (user != null) {
+        if (user != null && !isCurrentUser) {
             Box {
                 var showMenu by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileState.kt
@@ -12,6 +12,8 @@ import tv.trakt.trakt.core.user.model.UserFollowRequest
 @Immutable
 internal data class UserProfileState(
     val user: User,
+    val isCurrentUser: Boolean = false,
+    val accessChecking: Boolean = user.isPrivate,
     val userBlocked: BlockedState = BlockedState(),
     val userFollowing: FollowingState = FollowingState(),
     val userRequest: UserFollowRequestState = UserFollowRequestState(),
@@ -22,6 +24,20 @@ internal data class UserProfileState(
     val loading: LoadingState = LoadingState.Idle,
     val info: StringResource? = null,
 ) {
+    val access: Access
+        get() = when {
+            !user.isPrivate || isCurrentUser -> Access.Granted
+            accessChecking -> Access.Checking
+            userFollowing.following -> Access.Granted
+            else -> Access.Denied
+        }
+
+    enum class Access {
+        Checking,
+        Granted,
+        Denied,
+    }
+
     data class MonthlyStats(
         val stats: ProfileStats?,
         val backgroundUrl: String?,

--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/UserProfileViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import timber.log.Timber
+import tv.trakt.trakt.common.auth.session.SessionManager
 import tv.trakt.trakt.common.core.episodes.data.local.EpisodeLocalDataSource
 import tv.trakt.trakt.common.core.movies.data.local.MovieLocalDataSource
 import tv.trakt.trakt.common.core.shows.data.local.ShowLocalDataSource
@@ -49,6 +50,7 @@ import tv.trakt.trakt.resources.R
 
 internal class UserProfileViewModel(
     savedStateHandle: SavedStateHandle,
+    private val sessionManager: SessionManager,
     private val getUserProfileUseCase: GetUserProfileDetailsUseCase,
     private val getUserMonthUseCase: GetUserProfileMonthUseCase,
     private val getBlockedUsersUseCase: GetBlockedUsersUseCase,
@@ -68,6 +70,8 @@ internal class UserProfileViewModel(
     private val initialState = UserProfileState(user = user)
 
     private val userState = MutableStateFlow(initialState.user)
+    private val isCurrentUserState = MutableStateFlow(initialState.isCurrentUser)
+    private val accessCheckingState = MutableStateFlow(initialState.accessChecking)
     private val userBlockedState = MutableStateFlow(initialState.userBlocked)
     private val userFollowedState = MutableStateFlow(initialState.userFollowing)
     private val userRequestState = MutableStateFlow(initialState.userRequest)
@@ -80,64 +84,103 @@ internal class UserProfileViewModel(
     private val navigateEpisodeState = MutableStateFlow(initialState.navigateEpisode)
 
     private var processingJob: Job? = null
+    private var profileContentLoadStarted = false
 
     init {
         loadData()
     }
 
     private fun loadData() {
-        if (user.isPrivate) {
-            with(viewModelScope) {
-                launch { loadFollowingStatus() }
-                launch { loadBlockedStatus() }
+        viewModelScope.launch {
+            val isCurrentUser = loadCurrentUserStatus()
+            if (isCurrentUser) {
+                accessCheckingState.update { false }
+                userFollowedState.update { it.copy(loading = false) }
+                userBlockedState.update { it.copy(loading = false) }
+                loadProfileContent()
+                return@launch
             }
-            return
-        }
 
+            launch {
+                loadBlockedStatus()
+            }
+
+            if (!user.isPrivate) {
+                loadProfileContent()
+                launch {
+                    loadFollowingStatus()
+                }
+                return@launch
+            }
+
+            val isFollowing = loadFollowingStatus()
+            accessCheckingState.update { false }
+            if (isFollowing) {
+                loadProfileContent()
+            }
+        }
+    }
+
+    private suspend fun loadCurrentUserStatus(): Boolean {
+        return try {
+            val isCurrentUser = sessionManager.getProfile()?.ids?.trakt == user.ids.trakt
+            isCurrentUserState.update { isCurrentUser }
+            isCurrentUser
+        } catch (error: Exception) {
+            error.rethrowCancellation {
+                Timber.recordError(error)
+            }
+            false
+        }
+    }
+
+    private fun loadProfileContent() {
+        if (profileContentLoadStarted) return
+        profileContentLoadStarted = true
+
+        loadMonthBackground()
         with(viewModelScope) {
-            loadMonthBackground()
             launch { loadDetails() }
             launch { loadMonthStats() }
-            launch { loadFollowingStatus() }
             launch { loadRequestStatus() }
-            launch { loadBlockedStatus() }
         }
     }
 
-    private fun loadFollowingStatus() {
-        viewModelScope.launch {
-            try {
-                val social = getSocialUseCase.loadFollowingIds()
-                userFollowedState.update {
-                    it.copy(
-                        following = social.contains(user.ids.trakt),
-                        loading = false,
-                    )
-                }
-            } catch (error: Exception) {
-                error.rethrowCancellation {
-                    Timber.recordError(error)
-                }
-                userFollowedState.update {
-                    it.copy(loading = false)
-                }
+    private suspend fun loadFollowingStatus(): Boolean {
+        return try {
+            val isFollowing = getSocialUseCase.loadFollowingIds()
+                .contains(user.ids.trakt)
+
+            userFollowedState.update {
+                it.copy(
+                    following = isFollowing,
+                    loading = false,
+                )
             }
+
+            isFollowing
+        } catch (error: Exception) {
+            error.rethrowCancellation {
+                Timber.recordError(error)
+            }
+            userFollowedState.update {
+                it.copy(loading = false)
+            }
+            false
         }
     }
 
-    private fun loadRequestStatus() {
-        viewModelScope.launch {
-            try {
-                userRequestState.update {
-                    UserFollowRequestState(
-                        getSocialRequestsUseCase.loadRequests()
-                            .find { it.user.ids.trakt == user.ids.trakt },
-                    )
-                }
-            } catch (error: Exception) {
-                error.rethrowCancellation {
-                    Timber.recordError(error)
-                }
+    private suspend fun loadRequestStatus() {
+        try {
+            userRequestState.update {
+                UserFollowRequestState(
+                    getSocialRequestsUseCase.loadRequests()
+                        .find { it.user.ids.trakt == user.ids.trakt },
+                )
+            }
+        } catch (error: Exception) {
+            error.rethrowCancellation {
+                Timber.recordError(error)
             }
         }
     }
@@ -241,6 +284,7 @@ internal class UserProfileViewModel(
                         when (result) {
                             Approved -> {
                                 userFollowedState.update { it.copy(following = true) }
+                                loadProfileContent()
                                 infoState.update {
                                     DynamicStringResource(
                                         R.string.text_info_following,
@@ -410,6 +454,8 @@ internal class UserProfileViewModel(
 
     val state = combine(
         userState,
+        isCurrentUserState,
+        accessCheckingState,
         userBlockedState,
         userFollowedState,
         userRequestState,
@@ -422,15 +468,17 @@ internal class UserProfileViewModel(
     ) { states ->
         UserProfileState(
             user = states[0] as User,
-            userBlocked = states[1] as UserProfileState.BlockedState,
-            userFollowing = states[2] as UserProfileState.FollowingState,
-            userRequest = states[3] as UserFollowRequestState,
-            monthStats = states[4] as? UserProfileState.MonthlyStats,
-            loading = states[5] as LoadingState,
-            navigateShow = states[6] as? TraktId,
-            navigateMovie = states[7] as? TraktId,
-            navigateEpisode = states[8] as? Pair<TraktId, Episode>,
-            info = states[9] as? StringResource,
+            isCurrentUser = states[1] as Boolean,
+            accessChecking = states[2] as Boolean,
+            userBlocked = states[3] as UserProfileState.BlockedState,
+            userFollowing = states[4] as UserProfileState.FollowingState,
+            userRequest = states[5] as UserFollowRequestState,
+            monthStats = states[6] as? UserProfileState.MonthlyStats,
+            loading = states[7] as LoadingState,
+            navigateShow = states[8] as? TraktId,
+            navigateMovie = states[9] as? TraktId,
+            navigateEpisode = states[10] as? Pair<TraktId, Episode>,
+            info = states[11] as? StringResource,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/favorites/UserProfileFavoritesView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/favorites/UserProfileFavoritesView.kt
@@ -47,21 +47,26 @@ import tv.trakt.trakt.ui.theme.TraktTheme
 @Composable
 internal fun UserProfileFavoritesView(
     modifier: Modifier = Modifier,
-    viewModel: UserProfileFavoritesViewModel,
+    viewModel: UserProfileFavoritesViewModel?,
     headerPadding: PaddingValues,
     contentPadding: PaddingValues,
     onShowClick: ((Show) -> Unit)? = null,
     onMovieClick: ((Movie) -> Unit)? = null,
     onMoreClick: (() -> Unit)? = null,
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val collectedState = viewModel?.state?.collectAsStateWithLifecycle()?.value
+    val state = when {
+        collectedState == null -> UserProfileFavoritesState(loading = Loading)
+        collectedState.loading == Idle -> collectedState.copy(loading = Loading)
+        else -> collectedState
+    }
 
     UserProfileFavoritesContent(
         state = state,
         modifier = modifier,
         headerPadding = headerPadding,
         contentPadding = contentPadding,
-        onCollapse = viewModel::setCollapsed,
+        onCollapse = { viewModel?.setCollapsed(it) },
         onShowClick = { onShowClick?.invoke(it) },
         onMovieClick = { onMovieClick?.invoke(it) },
         onMoreClick = onMoreClick,

--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/history/UserProfileHistoryView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/history/UserProfileHistoryView.kt
@@ -49,7 +49,7 @@ import tv.trakt.trakt.ui.theme.TraktTheme
 @Composable
 internal fun UserProfileHistoryView(
     modifier: Modifier = Modifier,
-    viewModel: UserProfileHistoryViewModel,
+    viewModel: UserProfileHistoryViewModel?,
     headerPadding: PaddingValues,
     contentPadding: PaddingValues,
     onShowClick: ((Show) -> Unit)? = null,
@@ -57,14 +57,19 @@ internal fun UserProfileHistoryView(
     onMovieClick: ((Movie) -> Unit)? = null,
     onMoreClick: () -> Unit = {},
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val collectedState = viewModel?.state?.collectAsStateWithLifecycle()?.value
+    val state = when {
+        collectedState == null -> UserProfileHistoryState(loading = Loading)
+        collectedState.loading == Idle -> collectedState.copy(loading = Loading)
+        else -> collectedState
+    }
 
     UserProfileHistoryContent(
         state = state,
         modifier = modifier,
         headerPadding = headerPadding,
         contentPadding = contentPadding,
-        onCollapse = viewModel::setCollapsed,
+        onCollapse = { viewModel?.setCollapsed(it) },
         onShowClick = { onShowClick?.invoke(it) },
         onEpisodeClick = { show, episode -> onEpisodeClick?.invoke(show, episode) },
         onMovieClick = { onMovieClick?.invoke(it) },

--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/lists/UserProfileListsView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/lists/UserProfileListsView.kt
@@ -50,21 +50,26 @@ import tv.trakt.trakt.ui.theme.TraktTheme
 @Composable
 internal fun UserProfileListsView(
     modifier: Modifier = Modifier,
-    viewModel: UserProfileListsViewModel,
+    viewModel: UserProfileListsViewModel?,
     headerPadding: PaddingValues,
     contentPadding: PaddingValues,
     onListClick: (CustomList) -> Unit,
     onMoreClick: (PersonalListType) -> Unit = {},
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val collectedState = viewModel?.state?.collectAsStateWithLifecycle()?.value
+    val state = when {
+        collectedState == null -> UserProfileListsState(loading = Loading)
+        collectedState.loading == Idle -> collectedState.copy(loading = Loading)
+        else -> collectedState
+    }
 
     UserProfileListsContent(
         state = state,
         modifier = modifier,
         headerPadding = headerPadding,
         contentPadding = contentPadding,
-        onCollapse = viewModel::setCollapsed,
-        onFilterClick = viewModel::setFilter,
+        onCollapse = { viewModel?.setCollapsed(it) },
+        onFilterClick = { viewModel?.setFilter(it) },
         onListClick = onListClick,
         onMoreClick = {
             if (state.loading.isLoading) {

--- a/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/social/UserProfileSocialView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/userprofile/sections/social/UserProfileSocialView.kt
@@ -52,20 +52,25 @@ import tv.trakt.trakt.ui.theme.TraktTheme
 @Composable
 internal fun UserProfileSocialView(
     modifier: Modifier = Modifier,
-    viewModel: UserProfileSocialViewModel,
+    viewModel: UserProfileSocialViewModel?,
     headerPadding: PaddingValues,
     contentPadding: PaddingValues,
     onUserClick: ((User) -> Unit)? = null,
 ) {
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val collectedState = viewModel?.state?.collectAsStateWithLifecycle()?.value
+    val state = when {
+        collectedState == null -> UserProfileSocialState(loading = Loading)
+        collectedState.loading == Idle -> collectedState.copy(loading = Loading)
+        else -> collectedState
+    }
 
     UserProfileSocialContent(
         state = state,
         modifier = modifier,
         headerPadding = headerPadding,
         contentPadding = contentPadding,
-        onCollapse = viewModel::setCollapsed,
-        onFilterClick = viewModel::setFilter,
+        onCollapse = { viewModel?.setCollapsed(it) },
+        onFilterClick = { viewModel?.setFilter(it) },
         onUserClick = { onUserClick?.invoke(it) },
     )
 }

--- a/app/src/test/java/tv/trakt/trakt/core/userprofile/UserProfileStateTest.kt
+++ b/app/src/test/java/tv/trakt/trakt/core/userprofile/UserProfileStateTest.kt
@@ -1,0 +1,89 @@
+package tv.trakt.trakt.core.userprofile
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tv.trakt.trakt.common.helpers.preview.PreviewData
+
+class UserProfileStateTest {
+    @Test
+    fun `public profile grants access while following status is loading`() {
+        val state = UserProfileState(
+            user = PreviewData.user1.copy(isPrivate = false),
+            userFollowing = UserProfileState.FollowingState(
+                following = false,
+                loading = true,
+            ),
+        )
+
+        assertEquals(UserProfileState.Access.Granted, state.access)
+    }
+
+    @Test
+    fun `private profile checks access while following status is loading`() {
+        val state = UserProfileState(
+            user = PreviewData.user1.copy(isPrivate = true),
+            userFollowing = UserProfileState.FollowingState(
+                following = false,
+                loading = true,
+            ),
+        )
+
+        assertEquals(UserProfileState.Access.Checking, state.access)
+    }
+
+    @Test
+    fun `private profile grants access to approved follower`() {
+        val state = UserProfileState(
+            user = PreviewData.user1.copy(isPrivate = true),
+            accessChecking = false,
+            userFollowing = UserProfileState.FollowingState(
+                following = true,
+                loading = false,
+            ),
+        )
+
+        assertEquals(UserProfileState.Access.Granted, state.access)
+    }
+
+    @Test
+    fun `private profile grants access to profile owner`() {
+        val state = UserProfileState(
+            user = PreviewData.user1.copy(isPrivate = true),
+            isCurrentUser = true,
+            userFollowing = UserProfileState.FollowingState(
+                following = false,
+                loading = true,
+            ),
+        )
+
+        assertEquals(UserProfileState.Access.Granted, state.access)
+    }
+
+    @Test
+    fun `private profile denies access to non follower`() {
+        val state = UserProfileState(
+            user = PreviewData.user1.copy(isPrivate = true),
+            accessChecking = false,
+            userFollowing = UserProfileState.FollowingState(
+                following = false,
+                loading = false,
+            ),
+        )
+
+        assertEquals(UserProfileState.Access.Denied, state.access)
+    }
+
+    @Test
+    fun `private profile stays denied while follow request is loading`() {
+        val state = UserProfileState(
+            user = PreviewData.user1.copy(isPrivate = true),
+            accessChecking = false,
+            userFollowing = UserProfileState.FollowingState(
+                following = false,
+                loading = true,
+            ),
+        )
+
+        assertEquals(UserProfileState.Access.Denied, state.access)
+    }
+}


### PR DESCRIPTION
## Related Issues
- Partially addresses #248 (Fixes the private profile access issue for followed users, but does not address the search functionality)

## Scene Setting: A Clear Description

Private profiles should be accessible to approved followers while remaining hidden from users who do not have access. Profile owners should also be able to open their own private profile from another user's Following or Followers section.

When users view their own profile through this route, follow and block actions should not be available because these actions only apply when viewing another user.

Private profile access must be resolved before protected content is loaded while maintaining the same loading experience used by public profiles. Sending a follow request must also preserve the private profile warning without restarting the profile loading state.

This PR:

1. Introduces explicit `Checking`, `Granted`, and `Denied` profile access states.
2. Grants access to public profiles, approved followers, and the profile owner.
3. Resolves profile ownership by comparing the displayed Trakt user ID with the signed-in profile stored in `SessionManager`.
4. Verifies the approved following relationship before loading another user's private profile content.
5. Uses the existing Favorites, History, Lists, and Social loading design while private profile access is resolved.
6. Preserves composable instances across access resolution so shimmer animations remain continuous.
7. Defers private profile section ViewModels until access is granted.
8. Hides follow and block actions when the signed-in user opens their own profile.
9. Keeps the private profile warning visible for non-followers and pending follow requests.
10. Keeps follow request loading independent from profile access resolution so sending a request does not reload the profile screen.

## Show, Don't Tell: Screenshots and Videos

*No screenshots or videos are required. This change reuses the existing profile UI and loading skeletons while correcting access decisions, loading continuity, and self-action availability.*

## Testing: The Dress Rehearsal

Regression coverage has been added for the profile access policy, verifying that:

1. Public profiles remain accessible while following status is loading.
2. Private profiles stay in the checking state while initial access is unresolved.
3. Approved followers are granted access to private profiles.
4. Profile owners are granted access to their own private profiles.
5. Non-followers are denied access to private profiles.
6. Private profiles remain denied without re-entering the checking state while a follow request is being sent.

The following verification completed successfully:

- `.\gradlew.bat :app:testInternalDebugUnitTest --tests "tv.trakt.trakt.core.userprofile.UserProfileStateTest"`
- Kotlin compilation for the Internal Debug variant
- `git diff --check`

## Pull Request Checklist

- [x] **Clear and Concise Title:** Follows Conventional Commits with the allowed `app` scope.
- [x] **Detailed Description:** Documents private profile access, ownership, loading continuity, follow request behavior, and self-action availability.
- [x] **Screenshots/Videos:** N/A because the existing profile UI and loading design are reused.
- [x] **Tests:** Added regression coverage for public, private, followed, owner, denied, and follow-request loading states.
- [x] **Coding Standards:** Internal Debug Kotlin compilation passes and the diff check is clean.
- [x] **Commit Messages:** Follows the repository commit rules.
- [x] **Documentation:** No documentation updates are required for this profile behavior fix.
- [x] **Code Review:** Ready to address feedback.