### PR TITLE
fix: fall back to a populated department when known-for has no credits

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/summary/people/helpers/ResolveSelectedCreditsFilter.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/people/helpers/ResolveSelectedCreditsFilter.kt
@@ -1,11 +1,11 @@
-package tv.trakt.trakt.common.helpers
+package tv.trakt.trakt.core.summary.people.helpers
 
 private val NON_PREFERRED_CREDITS_FILTERS = setOf("self", "narrator")
 
 /**
  * Picks the default department filter for a person's credits list. Honors
  * [knownForDepartment] when it actually matches one of [listItems]'s
- * departments. Otherwise ranks the remaining departments by credit count,
+ * departments. Otherwise, ranks the remaining departments by credit count,
  * preferring acting/crew departments over self/narrator - but falling back
  * to those when they're the only credits the person has, so a documentary
  * subject with only "self" appearances still gets a populated default

--- a/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/MoviesCreditsList.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/MoviesCreditsList.kt
@@ -43,12 +43,12 @@ import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
 import tv.trakt.trakt.common.helpers.extensions.rememberDurationFormat
 import tv.trakt.trakt.common.helpers.extensions.toLocal
 import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
-import tv.trakt.trakt.common.helpers.resolveSelectedCreditsFilter
 import tv.trakt.trakt.common.model.MediaType.Movie
 import tv.trakt.trakt.common.model.Movie
 import tv.trakt.trakt.common.model.Person
 import tv.trakt.trakt.core.summary.people.ListEmptyView
 import tv.trakt.trakt.core.summary.people.ListLoadingView
+import tv.trakt.trakt.core.summary.people.helpers.resolveSelectedCreditsFilter
 import tv.trakt.trakt.core.summary.people.model.PersonCreditItem
 import tv.trakt.trakt.resources.R
 import tv.trakt.trakt.ui.components.TraktHeader

--- a/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/MoviesCreditsList.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/MoviesCreditsList.kt
@@ -43,6 +43,7 @@ import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
 import tv.trakt.trakt.common.helpers.extensions.rememberDurationFormat
 import tv.trakt.trakt.common.helpers.extensions.toLocal
 import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
+import tv.trakt.trakt.common.helpers.resolveSelectedCreditsFilter
 import tv.trakt.trakt.common.model.MediaType.Movie
 import tv.trakt.trakt.common.model.Movie
 import tv.trakt.trakt.common.model.Person
@@ -89,10 +90,9 @@ internal fun MoviesCreditsList(
         ) {
             TraktHeader(
                 title = stringResource(R.string.page_title_movies),
-                subtitle = when (listItems.keys.size) {
-                    1 -> stringResource(R.string.translated_value_position_acting)
-                    else -> null
-                },
+                subtitle = listItems.keys.singleOrNull()
+                    ?.takeIf { it.equals("acting", ignoreCase = true) }
+                    ?.let { stringResource(R.string.translated_value_position_acting) },
             )
         }
 
@@ -115,7 +115,10 @@ internal fun MoviesCreditsList(
                         )
                     } else {
                         var selectedFilter by rememberSaveable {
-                            mutableStateOf(person.knownForDepartment ?: listItems.keys.first())
+                            mutableStateOf(
+                                resolveSelectedCreditsFilter(listItems, person.knownForDepartment)
+                                    ?: listItems.keys.first(),
+                            )
                         }
 
                         Column {

--- a/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/ShowsCreditsList.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/ShowsCreditsList.kt
@@ -41,6 +41,7 @@ import tv.trakt.trakt.common.helpers.LoadingState.Loading
 import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
 import tv.trakt.trakt.common.helpers.extensions.toLocal
 import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
+import tv.trakt.trakt.common.helpers.resolveSelectedCreditsFilter
 import tv.trakt.trakt.common.model.MediaType.Show
 import tv.trakt.trakt.common.model.Person
 import tv.trakt.trakt.common.model.Show
@@ -87,10 +88,9 @@ internal fun ShowsCreditsList(
         ) {
             TraktHeader(
                 title = stringResource(R.string.page_title_shows),
-                subtitle = when (listItems.keys.size) {
-                    1 -> stringResource(R.string.translated_value_position_acting)
-                    else -> null
-                },
+                subtitle = listItems.keys.singleOrNull()
+                    ?.takeIf { it.equals("acting", ignoreCase = true) }
+                    ?.let { stringResource(R.string.translated_value_position_acting) },
             )
         }
 
@@ -114,7 +114,10 @@ internal fun ShowsCreditsList(
                     } else {
                         Column {
                             var selectedFilter by remember {
-                                mutableStateOf(person.knownForDepartment ?: listItems.keys.first())
+                                mutableStateOf(
+                                    resolveSelectedCreditsFilter(listItems, person.knownForDepartment)
+                                        ?: listItems.keys.first(),
+                                )
                             }
 
                             if (listItems.keys.size > 1) {

--- a/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/ShowsCreditsList.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/people/ui/ShowsCreditsList.kt
@@ -41,12 +41,12 @@ import tv.trakt.trakt.common.helpers.LoadingState.Loading
 import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableList
 import tv.trakt.trakt.common.helpers.extensions.toLocal
 import tv.trakt.trakt.common.helpers.extensions.uppercaseWords
-import tv.trakt.trakt.common.helpers.resolveSelectedCreditsFilter
 import tv.trakt.trakt.common.model.MediaType.Show
 import tv.trakt.trakt.common.model.Person
 import tv.trakt.trakt.common.model.Show
 import tv.trakt.trakt.core.summary.people.ListEmptyView
 import tv.trakt.trakt.core.summary.people.ListLoadingView
+import tv.trakt.trakt.core.summary.people.helpers.resolveSelectedCreditsFilter
 import tv.trakt.trakt.core.summary.people.model.PersonCreditItem
 import tv.trakt.trakt.resources.R
 import tv.trakt.trakt.ui.components.TraktHeader

--- a/common/src/main/java/tv/trakt/trakt/common/helpers/ResolveSelectedCreditsFilter.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/helpers/ResolveSelectedCreditsFilter.kt
@@ -1,0 +1,26 @@
+package tv.trakt.trakt.common.helpers
+
+private val NON_PREFERRED_CREDITS_FILTERS = setOf("self", "narrator")
+
+/**
+ * Picks the default department filter for a person's credits list. Honors
+ * [knownForDepartment] when it actually matches one of [listItems]'s
+ * departments. Otherwise ranks the remaining departments by credit count,
+ * preferring acting/crew departments over self/narrator - but falling back
+ * to those when they're the only credits the person has, so a documentary
+ * subject with only "self" appearances still gets a populated default
+ * instead of an empty list. Returns null when [listItems] is empty - callers
+ * should fall back to their own default rather than crash.
+ */
+fun <T> resolveSelectedCreditsFilter(
+    listItems: Map<String, List<T>>,
+    knownForDepartment: String?,
+): String? {
+    val validKnownFor = listItems.keys.firstOrNull { it.equals(knownForDepartment, ignoreCase = true) }
+    if (validKnownFor != null) return validKnownFor
+
+    val preferred = listItems.keys.filterNot { it.lowercase() in NON_PREFERRED_CREDITS_FILTERS }
+    val candidates = preferred.ifEmpty { listItems.keys }
+
+    return candidates.maxByOrNull { listItems.getValue(it).size }
+}


### PR DESCRIPTION
⚠️ I haven't tried running this code. Example person with this issue: https://app.trakt.tv/people/rob-font

---

Person summary credits (Movies/Shows tabs) could default the department filter to one the person has zero credits in - e.g. `knownForDepartment` says "Acting" but this credits list only has "self" entries - silently rendering an empty row.

- Also fixes the section subtitle hardcoding "Acting" whenever there's exactly one department, even when that department is actually self or narrator.

**Verification:**
- [ ] `:app:compileInternalDebugKotlin` and `:common:compileInternalDebugKotlin` succeed
- [ ] Manually check the Movies and Shows credits rows on a person summary screen, particularly for a person whose only credits are self/narrator appearances, and the subtitle label under "Movies"/"Shows" when there's exactly one department

Refs: [iOS](https://github.com/trakt/trakt-apple-internal/pull/305)/[Web](https://github.com/trakt/trakt-web/pull/3077)