### PR TITLE
fix: remove 1-year cap on previous-streak lookback

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/home/sections/streaks/data/DefaultStreaksManager.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/home/sections/streaks/data/DefaultStreaksManager.kt
@@ -129,10 +129,14 @@ internal class DefaultStreaksManager(
         today: LocalDate,
         currentStreak: Int,
     ): Int {
+        // Bound the backward search by the earliest real activity instead of a fixed
+        // lookback window, so a previous streak from over a year ago still counts.
+        val earliestActiveDay = activitySet.minOrNull() ?: return 0
+
         // When today is inactive the current streak anchors to yesterday, so shift by 1 extra
         val offset = if (today in activitySet) currentStreak else currentStreak + 1
         var day = today.minusDays(offset.toLong())
-        while (day !in activitySet && day.isAfter(today.minusYears(1))) {
+        while (day !in activitySet && day.isAfter(earliestActiveDay)) {
             day = day.minusDays(1)
         }
         var streak = 0


### PR DESCRIPTION
⚠️ I haven't tried running this code

---

`computePreviousStreak` gave up searching for the previous streak's end date once it passed one year before today, so any previous streak that ended further back than that was reported as 0 instead of its real length. This diverged from the iOS and web implementations, which scan the full watch history with no time bound.

The fix bounds the backward search by the earliest day actually present in the activity set instead of a fixed calendar window — removes the artificial cap while still guaranteeing the loop terminates.

**Test plan (needs a real run, not just a read-through)**
- [ ] Build and install a debug build, confirm it compiles clean
- [ ] On an account with a previous streak that ended over a year ago, confirm it now shows the real length instead of 0
- [ ] On an account with no watch history, confirm `previousStreak` still shows 0 (empty-set guard didn't break the normal case)
- [ ] Spot-check a normal account (previous streak within the last year) still matches pre-fix behavior, to confirm nothing regressed for the common case