### PR TITLE
fix: give previous streak its own subtitle

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/home/sections/streaks/all/StreaksView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/home/sections/streaks/all/StreaksView.kt
@@ -104,9 +104,7 @@ private fun StreaksViewContent(
             StreakStatCard(
                 value = data.previousStreakTotal.toString(),
                 label = stringResource(R.string.label_stats_previous_streak),
-                subtitle = stringResource(R.string.label_stats_days_active)
-                    .lowercase()
-                    .capitalize(),
+                subtitle = stringResource(R.string.text_stats_ended),
                 modifier = Modifier.weight(1f),
             )
         }

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -1559,6 +1559,7 @@
   <string name="text_stats_delta_down">-%d</string>
   <string name="text_stats_delta_same">No change</string>
   <string name="text_stats_delta_up">+%d</string>
+  <string name="text_stats_ended">Ended</string>
   <string name="text_stats_episodes_count">%d episodes</string>
   <string name="text_stats_keep_it_going">Keep it going!</string>
   <string name="text_stats_movies_count">%d movies</string>


### PR DESCRIPTION
Probably want to wait for https://github.com/trakt/trakt-web/pull/3079 to be approved and merged before merging.

---

Previous streak's subtitle was reusing the "Active Days" label lowercased, which read oddly out of context. Adds a dedicated "Ended" string instead.

**Test plan**
- [ ] Build and confirm it compiles clean
- [ ] Open the streak screen, confirm Previous Streak now shows "Ended" instead of "active days"