### PR TITLE
feat(app): split up to date progress filter into up to date and ended

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/ProfileProgressView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/ProfileProgressView.kt
@@ -275,7 +275,7 @@ private fun Preview3() {
         ProfileProgressContent(
             state = ProfileProgressState(
                 loading = Done,
-                filter = ProgressFilter.Completed,
+                filter = ProgressFilter.UpToDate,
                 items = EmptyImmutableList,
             ),
         )

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/ProfileProgressViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/ProfileProgressViewModel.kt
@@ -31,9 +31,11 @@ import tv.trakt.trakt.core.lists.ListsConfig.PROGRESS_SECTION_LIMIT
 import tv.trakt.trakt.core.profile.sections.progress.filters.GetProgressFilterUseCase
 import tv.trakt.trakt.core.profile.sections.progress.model.ProfileProgressItem
 import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter
-import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.Completed
 import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.Dropped
+import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.Ended
 import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.InProgress
+import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.UpToDate
+import tv.trakt.trakt.core.profile.sections.progress.model.pageOfEnded
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressCompleteUseCase
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressDroppedUseCase
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressWatchingUseCase
@@ -103,7 +105,8 @@ internal class ProfileProgressViewModel(
 
                 itemsState.update {
                     when (filter) {
-                        Completed -> getCompletedUseCase.getLocalCompleted(PROGRESS_SECTION_LIMIT)
+                        UpToDate -> getCompletedUseCase.getLocalCompleted(PROGRESS_SECTION_LIMIT, ended = false)
+                        Ended -> getCompletedUseCase.getLocalCompleted(PROGRESS_SECTION_LIMIT, ended = true)
                         InProgress -> getWatchingUseCase.getLocalWatching(PROGRESS_SECTION_LIMIT)
                         Dropped -> getDroppedUseCase.getLocalDropped(PROGRESS_SECTION_LIMIT)
                     }
@@ -118,7 +121,18 @@ internal class ProfileProgressViewModel(
 
                 itemsState.update {
                     when (filter) {
-                        Completed -> getCompletedUseCase.getCompleted(page = 1, limit = PROGRESS_SECTION_LIMIT)
+                        UpToDate ->
+                            getCompletedUseCase
+                                .getCompleted(page = 1, limit = PROGRESS_SECTION_LIMIT)
+                                .pageOfEnded(ended = false)
+                                .items
+
+                        Ended ->
+                            getCompletedUseCase
+                                .getCompleted(page = 1, limit = PROGRESS_SECTION_LIMIT)
+                                .pageOfEnded(ended = true)
+                                .items
+
                         InProgress -> getWatchingUseCase.getWatching(page = 1, limit = PROGRESS_SECTION_LIMIT)
                         Dropped -> getDroppedUseCase.getDropped(page = 1, limit = PROGRESS_SECTION_LIMIT)
                     }

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/all/AllProgressScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/all/AllProgressScreen.kt
@@ -135,7 +135,7 @@ internal fun AllProgressContent(
         ContentList(
             listItems = (state.items ?: emptyList()).toImmutableList(),
             listState = listState,
-            listFilter = state.filter ?: ProgressFilter.Completed,
+            listFilter = state.filter ?: ProgressFilter.UpToDate,
             contentPadding = contentPadding,
             loading = state.loading.isLoading,
             loadingMore = state.loadingMore.isLoading,

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/all/AllProgressViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/all/AllProgressViewModel.kt
@@ -34,9 +34,13 @@ import tv.trakt.trakt.core.lists.ListsConfig.PROGRESS_PAGE_LIMIT
 import tv.trakt.trakt.core.profile.sections.progress.filters.GetProgressFilterUseCase
 import tv.trakt.trakt.core.profile.sections.progress.model.ProfileProgressItem
 import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter
-import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.Completed
 import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.Dropped
+import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.Ended
 import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.InProgress
+import tv.trakt.trakt.core.profile.sections.progress.model.ProgressFilter.UpToDate
+import tv.trakt.trakt.core.profile.sections.progress.model.ProgressPage
+import tv.trakt.trakt.core.profile.sections.progress.model.asPage
+import tv.trakt.trakt.core.profile.sections.progress.model.pageOfEnded
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressCompleteUseCase
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressDroppedUseCase
 import tv.trakt.trakt.core.profile.sections.progress.usecase.GetProgressWatchingUseCase
@@ -110,7 +114,7 @@ internal class AllProgressViewModel(
 
                 itemsState.update {
                     fetchLocalData(
-                        filter = filterState.value ?: Completed,
+                        filter = filterState.value ?: UpToDate,
                     )
                 }
 
@@ -121,13 +125,13 @@ internal class AllProgressViewModel(
                     }
                 }
 
-                val items = fetchData(
-                    filter = filterState.value ?: Completed,
+                val page = fetchData(
+                    filter = filterState.value ?: UpToDate,
                     page = 1,
                 )
 
-                itemsState.update { items }
-                hasMoreData = items.size >= PROGRESS_PAGE_LIMIT
+                itemsState.update { page.items }
+                hasMoreData = page.fetched >= PROGRESS_PAGE_LIMIT
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     if (!ignoreErrors) {
@@ -151,18 +155,18 @@ internal class AllProgressViewModel(
                 loadingMoreState.update { Loading }
 
                 val nextPage = page + 1
-                val filter = filterState.value ?: Completed
-                val newItems = fetchData(filter, page = nextPage)
+                val filter = filterState.value ?: UpToDate
+                val newPage = fetchData(filter, page = nextPage)
 
                 itemsState.update { items ->
                     items
-                        ?.plus(newItems)
+                        ?.plus(newPage.items)
                         ?.distinctBy { it.key }
                         ?.toImmutableList()
                 }
 
                 page = nextPage
-                hasMoreData = newItems.size >= PROGRESS_PAGE_LIMIT
+                hasMoreData = newPage.fetched >= PROGRESS_PAGE_LIMIT
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     errorState.update { error }
@@ -176,7 +180,8 @@ internal class AllProgressViewModel(
 
     private suspend fun fetchLocalData(filter: ProgressFilter): ImmutableList<ProfileProgressItem> {
         return when (filter) {
-            Completed -> getCompletedUseCase.getLocalCompleted(limit = PROGRESS_PAGE_LIMIT)
+            UpToDate -> getCompletedUseCase.getLocalCompleted(limit = PROGRESS_PAGE_LIMIT, ended = false)
+            Ended -> getCompletedUseCase.getLocalCompleted(limit = PROGRESS_PAGE_LIMIT, ended = true)
             InProgress -> getWatchingUseCase.getLocalWatching(limit = PROGRESS_PAGE_LIMIT)
             Dropped -> getDroppedUseCase.getLocalDropped(limit = PROGRESS_PAGE_LIMIT)
         }
@@ -185,11 +190,27 @@ internal class AllProgressViewModel(
     private suspend fun fetchData(
         filter: ProgressFilter,
         page: Int,
-    ): ImmutableList<ProfileProgressItem> {
+    ): ProgressPage {
         return when (filter) {
-            Completed -> getCompletedUseCase.getCompleted(page = page, limit = PROGRESS_PAGE_LIMIT)
-            InProgress -> getWatchingUseCase.getWatching(page = page, limit = PROGRESS_PAGE_LIMIT)
-            Dropped -> getDroppedUseCase.getDropped(page = page, limit = PROGRESS_PAGE_LIMIT)
+            UpToDate ->
+                getCompletedUseCase
+                    .getCompleted(page = page, limit = PROGRESS_PAGE_LIMIT)
+                    .pageOfEnded(ended = false)
+
+            Ended ->
+                getCompletedUseCase
+                    .getCompleted(page = page, limit = PROGRESS_PAGE_LIMIT)
+                    .pageOfEnded(ended = true)
+
+            InProgress ->
+                getWatchingUseCase
+                    .getWatching(page = page, limit = PROGRESS_PAGE_LIMIT)
+                    .asPage()
+
+            Dropped ->
+                getDroppedUseCase
+                    .getDropped(page = page, limit = PROGRESS_PAGE_LIMIT)
+                    .asPage()
         }
     }
 

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/filters/GetProgressFilterUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/filters/GetProgressFilterUseCase.kt
@@ -15,7 +15,7 @@ internal class GetProgressFilterUseCase(
         val storedFilter = dataStore.data.first()[KEY_PROGRESS_FILTER]
         return storedFilter?.let {
             runCatching { ProgressFilter.valueOf(it) }.getOrNull()
-        } ?: ProgressFilter.Completed
+        } ?: ProgressFilter.UpToDate
     }
 
     suspend fun setFilter(filter: ProgressFilter) {

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/model/ProgressFilter.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/model/ProgressFilter.kt
@@ -10,7 +10,8 @@ internal enum class ProgressFilter(
     @param:StringRes val displayRes: Int,
     @param:DrawableRes val iconRes: Int,
 ) {
-    Completed(R.string.button_text_progress_completed, R.drawable.ic_check_double),
+    UpToDate(R.string.button_text_progress_completed, R.drawable.ic_check_double),
+    Ended(R.string.translated_value_status_ended, R.drawable.ic_flag_checker),
     InProgress(R.string.button_text_progress_in_progress, R.drawable.ic_hourglass),
     Dropped(R.string.button_text_progress_dropped, R.drawable.ic_drop),
 }

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/model/ProgressPage.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/model/ProgressPage.kt
@@ -1,0 +1,34 @@
+package tv.trakt.trakt.core.profile.sections.progress.model
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+/**
+ * A page of progress items together with how many items the endpoint actually returned.
+ *
+ * [items] may be shorter than [fetched] when the caller splits a bucket by show status.
+ * Paging has to key off [fetched], since a page that filters down to fewer items than the
+ * page limit still means there is another page behind it.
+ */
+internal data class ProgressPage(
+    val items: ImmutableList<ProfileProgressItem>,
+    val fetched: Int,
+)
+
+internal fun ImmutableList<ProfileProgressItem>.asPage(): ProgressPage {
+    return ProgressPage(items = this, fetched = size)
+}
+
+/**
+ * Splits the completed bucket on show status. The up next endpoint has no status filter,
+ * so a show that ended and a show the user is merely caught up with arrive together and
+ * are told apart here.
+ */
+internal fun ImmutableList<ProfileProgressItem>.pageOfEnded(ended: Boolean): ProgressPage {
+    return ProgressPage(
+        items = filterIsInstance<ProfileProgressItem.ShowItem>()
+            .filter { it.show.hasEnded == ended }
+            .toImmutableList(),
+        fetched = size,
+    )
+}

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/usecase/GetProgressCompleteUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/usecase/GetProgressCompleteUseCase.kt
@@ -13,9 +13,18 @@ internal class GetProgressCompleteUseCase(
     private val remoteShowsSyncSource: ShowsSyncRemoteDataSource,
     private val localDataSource: ProgressCompletedLocalDataSource,
 ) {
-    suspend fun getLocalCompleted(limit: Int): ImmutableList<ProfileProgressItem> {
+    /**
+     * Reads the cached completed bucket, keeping only shows that have ended or only shows
+     * still airing. Filtering happens before [limit] is applied so a caller asking for N
+     * items is not short-changed by whatever the cache happens to hold first.
+     */
+    suspend fun getLocalCompleted(
+        limit: Int,
+        ended: Boolean,
+    ): ImmutableList<ProfileProgressItem> {
         return localDataSource.getItems()
             .filterIsInstance<ProfileProgressItem.ShowItem>()
+            .filter { it.show.hasEnded == ended }
             .take(limit)
             .toImmutableList()
     }

--- a/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/views/ProgressFilters.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/profile/sections/progress/views/ProgressFilters.kt
@@ -80,7 +80,7 @@ internal fun ProgressFilters(
 private fun Preview() {
     TraktTheme {
         ProgressFilters(
-            selected = ProgressFilter.Completed,
+            selected = ProgressFilter.UpToDate,
         )
     }
 }

--- a/common/src/main/java/tv/trakt/trakt/common/model/Show.kt
+++ b/common/src/main/java/tv/trakt/trakt/common/model/Show.kt
@@ -12,6 +12,8 @@ import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
 import tv.trakt.trakt.common.helpers.extensions.toInstant
 import tv.trakt.trakt.common.helpers.serializers.ImmutableListSerializer
 import tv.trakt.trakt.common.helpers.serializers.InstantSerializer
+import tv.trakt.trakt.common.model.MediaStatus.Canceled
+import tv.trakt.trakt.common.model.MediaStatus.Ended
 import tv.trakt.trakt.common.model.MediaStatus.Released
 import tv.trakt.trakt.common.model.Show.Companion
 import tv.trakt.trakt.common.networking.RecommendedShowDto
@@ -58,6 +60,13 @@ data class Show(
     val isReleased: Boolean
         get() = status == Released ||
             releasedAt?.let { !it.isAfter(nowUtcInstant()) } ?: false
+
+    /**
+     * True when the show will not air any new episode, either because it wrapped up
+     * or because it was canceled. An unknown status counts as still airing.
+     */
+    val hasEnded: Boolean
+        get() = status == Ended || status == Canceled
 
     @Composable
     fun rememberReleased(): Boolean {


### PR DESCRIPTION
Closes #353

Scoped to the split alone: no counts, no settings toggle, no API change. Mirrors trakt/trakt-web#3211, which does the same thing on the web.

### Why

The `Up to date` filter in Profile > Progress answers two different questions at once. It returns every show whose aired episodes are all watched, so a series that wrapped up years ago sits next to a series that is still airing and simply has nothing unwatched right now. From the Progress section there is no way to tell which shows are actually finished without opening each one.

### What changed

`Up to date` becomes two filters: **Up to date** (still airing, caught up) and **Ended** (status `ended` or `canceled`). `In progress` and `Dropped` are untouched.

- **No API change.** `up_next_nitro` returns the full show object with `status`, so both filters read the same `intent=completed` bucket and partition it on that status. Verified against the live API: 16 completed, 10 `ended`, 6 `returning series`, 0 without a status.
- **`Show.hasEnded` sits in `:common`** next to `Show.isReleased`, since it is a question about a show rather than about this screen. An unknown status counts as still airing, which preserves today's behaviour.
- **Paging keys off the raw page size.** This is the one subtlety. Partitioning a page client-side shrinks it, and the pager previously decided `hasMoreData` from the size of what it received. Left alone, a page of 100 completed shows that filters down to 8 ended ones would have ended pagination early. `ProgressPage` carries the count the endpoint actually returned alongside the filtered items, and the pager reads that.
- **The chips need no UI change.** `ProgressFilters` already iterates `ProgressFilter.entries`, so adding the enum entry is enough. `ic_flag_checker` already existed.
- **The `ProgressFilter` entry `Completed` became `UpToDate`,** so a stored `"Completed"` no longer parses. `GetProgressFilterUseCase` already falls back to the default on an unknown value, and the default is `UpToDate`, which carries the same label users saw before. No migration needed.

### Localisation

No new translatable keys. `Up to date` keeps `button_text_progress_completed` and `Ended` reuses `translated_value_status_ended`, both already translated in every locale, so this ships localised rather than waiting on a Crowdin round trip.

### Notes

One consequence of partitioning client-side: the profile Progress row asks for `PROGRESS_SECTION_LIMIT` items and then splits them, so that preview row can show fewer than the limit. The all-progress screen is unaffected, since it pages. Calling it out rather than hiding it; the alternative would be over-fetching to fill the row, which is not worth it for a preview.

### Testing

`./gradlew :app:compileInternalDebugKotlin` clean, ktlint 1.7.1 (the version CI runs) clean.

