### PR TITLE
fix(comments): respect app locale for language flags

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
@@ -30,7 +30,7 @@ internal data class CommentsLanguage(
  * the display name and representative flag.
  */
 internal fun commentsLanguages(
-    appLocale: Locale,
+    appLocale: Locale = activeAppLocale(),
 ): ImmutableList<CommentsLanguage> {
     return BuildConfig.SUPPORTED_LOCALES
         .map { Locale.forLanguageTag(it) }
@@ -66,7 +66,7 @@ internal fun commentsLanguages(
  * - a system locale the app isn't localised into would otherwise filter every comment away.
  */
 internal fun appCommentsLanguage(): String? {
-    val locale = AppCompatDelegate.getApplicationLocales().get(0) ?: Locale.getDefault()
+    val locale = activeAppLocale()
     val code = locale.apiLanguage
 
     if (commentsLanguages(locale).none { it.code == code }) return null
@@ -78,15 +78,21 @@ internal fun appCommentsLanguage(): String? {
  * Display name for a stored language [code], or null when the code is unknown or absent
  * (absent means "all languages").
  */
-internal fun commentsLanguageDisplayName(
-    code: String?,
-    appLocale: Locale,
-): String? {
+internal fun commentsLanguageDisplayName(code: String?): String? {
     if (code == null) return null
 
-    return commentsLanguages(appLocale)
+    return commentsLanguages()
         .firstOrNull { it.code == code }
         ?.displayName
+}
+
+/**
+ * Returns the active locale selected for the application. When no per-app language has been
+ * selected, the application follows the system locale.
+ */
+private fun activeAppLocale(): Locale {
+    return AppCompatDelegate.getApplicationLocales().get(0)
+        ?: Locale.getDefault()
 }
 
 /**

--- a/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
@@ -23,30 +23,21 @@ internal data class CommentsLanguage(
 )
 
 /**
- * Languages the app itself is localised into, grouped by API language code so regional variants
- * (`en-US` / `en-AU`, `pt-BR` / `pt-PT`) collapse into a single option.
- *
- * When multiple regional variants exist, the variant matching the active app locale is preferred
- * for the display name and representative flag. If no exact regional match exists, the first
- * supported variant is used.
+ * Languages the app itself is localised into, de-duplicated by API language code so regional
+ * variants (`en-US` / `en-AU`, `pt-BR` / `pt-PT`) collapse into a single option, sorted by display
+ * name.
  */
-internal fun commentsLanguages(
-    appLocale: Locale = activeAppLocale(),
-): ImmutableList<CommentsLanguage> {
+internal fun commentsLanguages(): ImmutableList<CommentsLanguage> {
+    val appLocale = activeAppLocale()
+
     return BuildConfig.SUPPORTED_LOCALES
         .map { Locale.forLanguageTag(it) }
-        .groupBy { it.apiLanguage }
-        .values
-        .map { variants ->
-            variants.firstOrNull { locale ->
-                locale.language == appLocale.language &&
-                    locale.country == appLocale.country
-            } ?: variants.first()
-        }
+        .distinctBy { it.apiLanguage }
         .map { locale ->
             CommentsLanguage(
                 code = locale.apiLanguage,
-                // Use the regional variant matching the active app locale whenever possible.
+                // Display name comes from the app locale, not from the API code: `nb` maps to the
+                // `no` macrolanguage, which would otherwise read as the generic "norsk".
                 displayName = locale.getDisplayLanguage(locale)
                     .replaceFirstChar { char ->
                         if (char.isLowerCase()) {
@@ -55,7 +46,7 @@ internal fun commentsLanguages(
                             char.toString()
                         }
                     },
-                flag = countryFlag(locale.flagCountry()),
+                flag = countryFlag(locale.flagCountry(appLocale)),
             )
         }
         .sortedBy { it.displayName }
@@ -70,7 +61,7 @@ internal fun appCommentsLanguage(): String? {
     val locale = activeAppLocale()
     val code = locale.apiLanguage
 
-    if (commentsLanguages(locale).none { it.code == code }) return null
+    if (commentsLanguages().none { it.code == code }) return null
 
     return code
 }
@@ -97,15 +88,22 @@ private fun activeAppLocale(): Locale {
 }
 
 /**
- * Country represented by a language's selected regional locale. The locale matching the active
- * app language is selected before this function is called. For bare language tags (`de`, `ja`),
- * ICU provides the most likely region.
+ * Returns the representative country for a language flag.
  *
- * A flag is only a visual representation of the language option; the API code remains
- * language-only, such as `pt`.
+ * When the language matches the active app language and the app locale includes
+ * a region, that region is used for the flag. Otherwise, the supported locale's
+ * region is preserved, falling back to ICU for locale tags without a country.
  */
-private fun Locale.flagCountry(): String {
-    return country.ifBlank {
-        ULocale.addLikelySubtags(ULocale.forLocale(this)).country
+private fun Locale.flagCountry(appLocale: Locale): String {
+    return when {
+        language == appLocale.language && appLocale.country.isNotBlank() -> {
+            appLocale.country
+        }
+
+        else -> {
+            country.ifBlank {
+                ULocale.addLikelySubtags(ULocale.forLocale(this)).country
+            }
+        }
     }
 }

--- a/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
@@ -23,20 +23,36 @@ internal data class CommentsLanguage(
 )
 
 /**
- * Languages the app itself is localised into, de-duplicated by API language code so regional
- * variants (`en-US` / `en-AU`, `pt-BR` / `pt-PT`) collapse into a single option, sorted by display
- * name.
+ * Languages the app itself is localised into, grouped by API language code so regional variants
+ * (`en-US` / `en-AU`, `pt-BR` / `pt-PT`) collapse into a single option.
+ *
+ * When multiple regional variants exist, the variant matching the active app locale is used for
+ * the display name and representative flag.
  */
-internal fun commentsLanguages(): ImmutableList<CommentsLanguage> {
+internal fun commentsLanguages(
+    appLocale: Locale,
+): ImmutableList<CommentsLanguage> {
     return BuildConfig.SUPPORTED_LOCALES
         .map { Locale.forLanguageTag(it) }
-        .distinctBy { it.apiLanguage }
+        .groupBy { it.apiLanguage }
+        .values
+        .map { variants ->
+            variants.firstOrNull { locale ->
+                locale.language == appLocale.language &&
+                    locale.country == appLocale.country
+            } ?: variants.first()
+        }
         .map { locale ->
             CommentsLanguage(
                 code = locale.apiLanguage,
+                // Use the regional variant matching the active app locale whenever possible.
                 displayName = locale.getDisplayLanguage(locale)
                     .replaceFirstChar { char ->
-                        if (char.isLowerCase()) char.titlecase(locale) else char.toString()
+                        if (char.isLowerCase()) {
+                            char.titlecase(locale)
+                        } else {
+                            char.toString()
+                        }
                     },
                 flag = countryFlag(locale.flagCountry()),
             )
@@ -52,7 +68,8 @@ internal fun commentsLanguages(): ImmutableList<CommentsLanguage> {
 internal fun appCommentsLanguage(): String? {
     val locale = AppCompatDelegate.getApplicationLocales().get(0) ?: Locale.getDefault()
     val code = locale.apiLanguage
-    if (commentsLanguages().none { it.code == code }) return null
+
+    if (commentsLanguages(locale).none { it.code == code }) return null
 
     return code
 }
@@ -61,17 +78,24 @@ internal fun appCommentsLanguage(): String? {
  * Display name for a stored language [code], or null when the code is unknown or absent
  * (absent means "all languages").
  */
-internal fun commentsLanguageDisplayName(code: String?): String? {
+internal fun commentsLanguageDisplayName(
+    code: String?,
+    appLocale: Locale,
+): String? {
     if (code == null) return null
 
-    return commentsLanguages().firstOrNull { it.code == code }?.displayName
+    return commentsLanguages(appLocale)
+        .firstOrNull { it.code == code }
+        ?.displayName
 }
 
 /**
- * Country a language's flag stands for: the region the app's own locale tag carries (`pt-BR`,
- * `en-US`), falling back to the region ICU considers most likely for a bare language (`de` -> `DE`,
- * `ja` -> `JP`). A flag is a rough stand-in for a language, so a language spoken in many countries
- * shows a single representative one.
+ * Country represented by a language's selected regional locale. The locale matching the active
+ * app language is selected before this function is called. For bare language tags (`de`, `ja`),
+ * ICU provides the most likely region.
+ *
+ * A flag is only a visual representation of the language option; the API code remains
+ * language-only, such as `pt`.
  */
 private fun Locale.flagCountry(): String {
     return country.ifBlank {

--- a/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/comments/model/CommentsLanguage.kt
@@ -26,8 +26,9 @@ internal data class CommentsLanguage(
  * Languages the app itself is localised into, grouped by API language code so regional variants
  * (`en-US` / `en-AU`, `pt-BR` / `pt-PT`) collapse into a single option.
  *
- * When multiple regional variants exist, the variant matching the active app locale is used for
- * the display name and representative flag.
+ * When multiple regional variants exist, the variant matching the active app locale is preferred
+ * for the display name and representative flag. If no exact regional match exists, the first
+ * supported variant is used.
  */
 internal fun commentsLanguages(
     appLocale: Locale = activeAppLocale(),


### PR DESCRIPTION
Updates the comments language filter to use the active app locale when choosing the representative flag for the current language.

Previously, regional variants sharing the same API language code were collapsed by keeping the first supported locale. This could result in Portuguese being displayed with the Brazilian flag even when the app was set to Portuguese (Portugal).

The representative flag now follows the active app locale whenever it matches the language option. For example:

- `pt-PT` displays Portuguese with the Portuguese flag
- `pt-BR` displays Portuguese with the Brazilian flag

The same logic applies to other supported regional variants.

This change only affects the representative flag. Regional variants remain grouped into a single language option, and the language-only code expected by the Trakt API, such as `pt`, remains unchanged.