### PR TITLE
feat(app): offer watched until here when a check skips episodes

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/ShowSeasonsState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/ShowSeasonsState.kt
@@ -3,6 +3,7 @@ package tv.trakt.trakt.core.summary.shows.features.seasons
 import androidx.compose.runtime.Immutable
 import tv.trakt.trakt.common.helpers.LoadingState
 import tv.trakt.trakt.common.helpers.StringResource
+import tv.trakt.trakt.common.model.Episode
 import tv.trakt.trakt.common.model.Show
 import tv.trakt.trakt.core.summary.shows.features.seasons.model.ShowSeasons
 
@@ -16,4 +17,5 @@ internal data class ShowSeasonsState(
     val info: StringResource? = null,
     val error: Exception? = null,
     val collapsed: Boolean? = null,
+    val watchedUntilPrompt: Episode? = null,
 )

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/ShowSeasonsView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/ShowSeasonsView.kt
@@ -114,7 +114,8 @@ internal fun ShowSeasonsView(
     var confirmRemoveSeasonSheet by remember { mutableStateOf(false) }
 
     var episodeDateSheet by remember { mutableStateOf<EpisodeItem?>(null) }
-    var episodeWatchedUntilSheet by remember { mutableStateOf<EpisodeItem?>(null) }
+    var episodeWatchedUntilSheet by remember { mutableStateOf<Episode?>(null) }
+    var confirmWatchedUntilSheet by remember { mutableStateOf<Episode?>(null) }
     var episodeContextSheet by remember { mutableStateOf<EpisodeItem?>(null) }
     var seasonDateSheet by remember { mutableStateOf(false) }
 
@@ -161,7 +162,7 @@ internal fun ShowSeasonsView(
             episodeDateSheet = it
         },
         onWatchedUntilClick = {
-            episodeWatchedUntilSheet = it
+            episodeWatchedUntilSheet = it.episode
         },
         onRemoveClick = {
             confirmRemoveEpisodeSheet = it
@@ -173,10 +174,25 @@ internal fun ShowSeasonsView(
 
     WatchedUntilSheet(
         show = state.show,
-        episode = episodeWatchedUntilSheet?.episode,
+        episode = episodeWatchedUntilSheet,
         onDismiss = {
             episodeWatchedUntilSheet = null
         },
+    )
+
+    ConfirmationSheet(
+        active = confirmWatchedUntilSheet != null,
+        title = stringResource(R.string.button_text_watched_until_here),
+        message = stringResource(
+            R.string.button_label_watched_until_here,
+            confirmWatchedUntilSheet?.title.orEmpty(),
+        ),
+        yesText = stringResource(R.string.button_text_watched_until_here),
+        onYes = {
+            episodeWatchedUntilSheet = confirmWatchedUntilSheet
+            confirmWatchedUntilSheet = null
+        },
+        onNo = { confirmWatchedUntilSheet = null },
     )
 
     ConfirmationSheet(
@@ -257,6 +273,13 @@ internal fun ShowSeasonsView(
             seasonDateSheet = false
         },
     )
+
+    LaunchedEffect(state.watchedUntilPrompt) {
+        state.watchedUntilPrompt?.let {
+            confirmWatchedUntilSheet = it
+            viewModel.clearWatchedUntilPrompt()
+        }
+    }
 
     LaunchedEffect(state.info) {
         if (state.info == null) {

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/ShowSeasonsViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/ShowSeasonsViewModel.kt
@@ -70,6 +70,7 @@ internal class ShowSeasonsViewModel(
     private val loadingEpisodeState = MutableStateFlow(initialState.loadingEpisode)
     private val loadingSeasonState = MutableStateFlow(initialState.loadingSeason)
     private val infoState = MutableStateFlow(initialState.info)
+    private val watchedUntilPromptState = MutableStateFlow(initialState.watchedUntilPrompt)
     private val errorState = MutableStateFlow(initialState.error)
     private val collapseState = MutableStateFlow(collapsingManager.isCollapsed(CollapsingKey.SHOW_SEASONS))
 
@@ -227,6 +228,13 @@ internal class ShowSeasonsViewModel(
             return
         }
 
+        // Read before the write: how many released episodes this check leaves
+        // behind, and whether it is a rewatch rather than a first play.
+        val skipped = itemsState.value.skippedEpisodesBefore(episode)
+        val wasWatched = itemsState.value.selectedSeasonEpisodes
+            .firstOrNull { it.episode.ids.trakt == episode.ids.trakt }
+            ?.isWatched == true
+
         viewModelScope.launch {
             val authenticated = sessionManager.isAuthenticated()
             if (!authenticated) {
@@ -261,6 +269,10 @@ internal class ShowSeasonsViewModel(
                 }
 
                 showDetailsUpdates.notifyUpdate(Seasons)
+
+                if (!wasWatched && skipped > 0) {
+                    watchedUntilPromptState.update { episode }
+                }
 
                 infoState.update {
                     DynamicStringResource(R.string.text_info_history_added)
@@ -479,6 +491,10 @@ internal class ShowSeasonsViewModel(
         infoState.update { null }
     }
 
+    fun clearWatchedUntilPrompt() {
+        watchedUntilPromptState.update { null }
+    }
+
     fun setCollapsed(collapsed: Boolean) {
         collapseState.update { collapsed }
         collapseJob?.cancel()
@@ -500,6 +516,7 @@ internal class ShowSeasonsViewModel(
         infoState,
         errorState,
         collapseState,
+        watchedUntilPromptState,
     ) { state ->
         ShowSeasonsState(
             show = state[0] as Show,
@@ -510,6 +527,7 @@ internal class ShowSeasonsViewModel(
             info = state[5] as StringResource?,
             error = state[6] as Exception?,
             collapsed = state[7] as Boolean,
+            watchedUntilPrompt = state[8] as Episode?,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsScreen.kt
@@ -90,6 +90,13 @@ internal fun AllShowSeasonsScreen(
         viewModel.clearInfo()
     }
 
+    LaunchedEffect(state.watchedUntilPrompt) {
+        state.watchedUntilPrompt?.let {
+            sheetState.confirmWatchedUntil = it
+            viewModel.clearWatchedUntilPrompt()
+        }
+    }
+
     LaunchedEffect(state.navigateEpisode) {
         state.navigateEpisode?.let {
             onEpisodeClick(it.first, it.second)

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsSheets.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsSheets.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import tv.trakt.trakt.common.model.Comment
+import tv.trakt.trakt.common.model.Episode
 import tv.trakt.trakt.common.model.MediaType
 import tv.trakt.trakt.common.model.User
 import tv.trakt.trakt.common.model.toTraktId
@@ -36,7 +37,8 @@ internal class AllShowSeasonsSheetState {
     var confirmMarkSeason by mutableStateOf(false)
     var confirmRemoveSeason by mutableStateOf(false)
     var episodeDate by mutableStateOf<EpisodeItem?>(null)
-    var episodeWatchedUntil by mutableStateOf<EpisodeItem?>(null)
+    var episodeWatchedUntil by mutableStateOf<Episode?>(null)
+    var confirmWatchedUntil by mutableStateOf<Episode?>(null)
     var episodeContext by mutableStateOf<EpisodeItem?>(null)
     var seasonDate by mutableStateOf(false)
     var postComment by mutableStateOf(false)
@@ -60,7 +62,7 @@ internal fun AllShowSeasonsSheets(
             sheetState.episodeDate = it
         },
         onWatchedUntilClick = {
-            sheetState.episodeWatchedUntil = it
+            sheetState.episodeWatchedUntil = it.episode
         },
         onRemoveClick = {
             sheetState.confirmRemoveEpisode = it
@@ -72,10 +74,25 @@ internal fun AllShowSeasonsSheets(
 
     WatchedUntilSheet(
         show = state.show,
-        episode = sheetState.episodeWatchedUntil?.episode,
+        episode = sheetState.episodeWatchedUntil,
         onDismiss = {
             sheetState.episodeWatchedUntil = null
         },
+    )
+
+    ConfirmationSheet(
+        active = sheetState.confirmWatchedUntil != null,
+        title = stringResource(R.string.button_text_watched_until_here),
+        message = stringResource(
+            R.string.button_label_watched_until_here,
+            sheetState.confirmWatchedUntil?.title.orEmpty(),
+        ),
+        yesText = stringResource(R.string.button_text_watched_until_here),
+        onYes = {
+            sheetState.episodeWatchedUntil = sheetState.confirmWatchedUntil
+            sheetState.confirmWatchedUntil = null
+        },
+        onNo = { sheetState.confirmWatchedUntil = null },
     )
 
     RemoveConfirmationSheet(

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsState.kt
@@ -33,6 +33,7 @@ internal data class AllShowSeasonsState(
     val loadingEpisode: LoadingState = LoadingState.Idle,
     val loadingSeason: LoadingState = LoadingState.Idle,
     val navigateEpisode: Pair<TraktId, Episode>? = null,
+    val watchedUntilPrompt: Episode? = null,
     val info: StringResource? = null,
     val error: Exception? = null,
 ) {

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/all/AllShowSeasonsViewModel.kt
@@ -122,6 +122,7 @@ internal class AllShowSeasonsViewModel(
     private val navigateEpisode = MutableStateFlow(initialState.navigateEpisode)
     private val infoState = MutableStateFlow(initialState.info)
     private val errorState = MutableStateFlow(initialState.error)
+    private val watchedUntilPromptState = MutableStateFlow(initialState.watchedUntilPrompt)
 
     private val reactions = SeasonReactionsController(
         scope = viewModelScope,
@@ -515,6 +516,13 @@ internal class AllShowSeasonsViewModel(
             return
         }
 
+        // Read before the write: how many released episodes this check leaves
+        // behind, and whether it is a rewatch rather than a first play.
+        val skipped = itemsState.value.skippedEpisodesBefore(episode)
+        val wasWatched = itemsState.value.selectedSeasonEpisodes
+            .firstOrNull { it.episode.ids.trakt == episode.ids.trakt }
+            ?.isWatched == true
+
         viewModelScope.launch {
             if (!sessionManager.isAuthenticated()) return@launch
 
@@ -545,6 +553,10 @@ internal class AllShowSeasonsViewModel(
 
                 showDetailsUpdates.notifyUpdate(Seasons)
                 showDetailsUpdates.notifyUpdate(AllSeasons)
+
+                if (!wasWatched && skipped > 0) {
+                    watchedUntilPromptState.update { episode }
+                }
 
                 infoState.update { DynamicStringResource(R.string.text_info_history_added) }
                 analytics.progress.logAddWatchedMedia(
@@ -767,6 +779,10 @@ internal class AllShowSeasonsViewModel(
         navigateEpisode.update { null }
     }
 
+    fun clearWatchedUntilPrompt() {
+        watchedUntilPromptState.update { null }
+    }
+
     @Suppress("UNCHECKED_CAST")
     val state = combine(
         showState,
@@ -782,6 +798,7 @@ internal class AllShowSeasonsViewModel(
         navigateEpisode,
         infoState,
         errorState,
+        watchedUntilPromptState,
         reactions.commentReactions,
         reactions.userReactions,
         rating.rating,
@@ -800,9 +817,10 @@ internal class AllShowSeasonsViewModel(
             navigateEpisode = state[10] as Pair<TraktId, Episode>?,
             info = state[11] as StringResource?,
             error = state[12] as Exception?,
-            commentReactions = state[13] as ImmutableMap<Int, ReactionsSummary>,
-            userReactions = state[14] as ImmutableMap<Int, Reaction?>,
-            seasonUserRating = state[15] as AllShowSeasonsState.UserRatingState,
+            watchedUntilPrompt = state[13] as Episode?,
+            commentReactions = state[14] as ImmutableMap<Int, ReactionsSummary>,
+            userReactions = state[15] as ImmutableMap<Int, Reaction?>,
+            seasonUserRating = state[16] as AllShowSeasonsState.UserRatingState,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/model/ShowSeasons.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/summary/shows/features/seasons/model/ShowSeasons.kt
@@ -13,6 +13,7 @@ import tv.trakt.trakt.common.helpers.extensions.EmptyImmutableSet
 import tv.trakt.trakt.common.model.CastPerson
 import tv.trakt.trakt.common.model.Comment
 import tv.trakt.trakt.common.model.CrewPerson
+import tv.trakt.trakt.common.model.Episode
 import tv.trakt.trakt.common.model.Season
 import tv.trakt.trakt.common.model.TraktId
 
@@ -33,6 +34,28 @@ internal data class ShowSeasons(
     val isSelectedSeasonWatched: Boolean
         get() = selectedSeasonEpisodes.isNotEmpty() &&
             selectedSeasonEpisodes.all { it.isWatched }
+
+    /**
+     * Released episodes still unwatched between the show's first episode and
+     * [episode]: the gaps a "watched until here" would fill. Specials are left
+     * out, matching what GetWatchedUntilEpisodesUseCase would actually mark.
+     */
+    fun skippedEpisodesBefore(episode: Episode): Int {
+        if (episode.season <= 0) return 0
+
+        val previousSeasons = seasons
+            .filter { it.season.number in 1 until episode.season }
+            .sumOf { it.unwatchedEpisodes.coerceAtLeast(0) }
+
+        val sameSeason = selectedSeasonEpisodes.count {
+            it.episode.season == episode.season &&
+                it.episode.number < episode.number &&
+                it.episode.isReleased &&
+                !it.isWatched
+        }
+
+        return previousSeasons + sameSeason
+    }
 
     /** Prepends a freshly posted [comment] to the selected season's comment list. */
     fun addComment(comment: Comment): ShowSeasons =


### PR DESCRIPTION
## Problem

Checking an episode in the seasons list marks only that episode. Skip ahead and every episode between the last watched one and the picked one stays unwatched, with nothing saying so: up next points at the gap, the season progress has holes, and the show quietly drifts out of sync.

**Watched until here** already fills exactly those gaps, but it sits behind the episode overflow menu and only for an unwatched episode, so the people using the check as their normal gesture never find it.

<!-- SCREENSHOT: 01-setup-lacuna-antes-do-check.png - S02, E07/E08/E09 unwatched, about to check E10 -->
<img width="250" alt="01-setup-lacuna-antes-do-check" src="https://github.com/user-attachments/assets/dd46c2cc-68bf-426a-8ec0-b7341d4bb25e" />


## Solution

The check keeps its behaviour. When it leaves released episodes behind, a prompt follows offering **Watched until here**; confirming opens the existing sheet, cancelling leaves just the episode that was checked.

- The gap spans previous seasons as well as the current one, because that is what **Watched until here** writes. Specials are excluded, matching `GetWatchedUntilEpisodesUseCase`.
- It is computed from state the screen already holds (per season watched counts plus the selected season episode list), so a check that skips nothing costs no extra request.
- A re-watch does not prompt.
- Wired on both screens that already host the sheet: the show details seasons row and All seasons.
- The anchor is marked before the sheet opens, so the sheet counts only the gaps and never gives the anchor a second play.

<!-- SCREENSHOT: 02-prompt-watched-until-here.png - the prompt right after the check -->
<img width="250" alt="02-prompt-watched-until-here" src="https://github.com/user-attachments/assets/382ebcb1-22fc-45c8-a064-a64bfa013632" />

<!-- SCREENSHOT: 03-sheet-3-episodios-ancora-fora.png - the existing sheet, "3 episodes" = E07/E08/E09, anchor excluded -->
<img width="250" alt="03-sheet-3-episodios-ancora-fora" src="https://github.com/user-attachments/assets/831bada2-7a06-478e-bad4-19f1f78b0f3b" />


## Files

- `app/.../seasons/model/ShowSeasons.kt` - new `skippedEpisodesBefore(episode)`, pure, no I/O
- `app/.../seasons/{ShowSeasonsState,ShowSeasonsViewModel}.kt` - `watchedUntilPrompt` field, set on a successful add, cleared by `clearWatchedUntilPrompt()`
- `app/.../seasons/ShowSeasonsView.kt` - `LaunchedEffect` bridging that field to a `ConfirmationSheet`
- `app/.../seasons/all/{AllShowSeasonsState,AllShowSeasonsViewModel,AllShowSeasonsScreen,AllShowSeasonsSheets}.kt` - the same on All seasons

The sheet state on both screens now holds an `Episode?` instead of an `EpisodeItem?`, since only the episode was ever read out of it.

Nothing changes in `:common`, `:resources`, networking, DI or the OpenAPI client.

## i18n

No new keys. Reuses `button_text_watched_until_here` (title and confirm), `button_label_watched_until_here` (message, already takes the episode title) and `button_text_cancel`, all translated across the 30 locales.

## Validation

Emulator API 31, real account, against `upstream/main`. `:app:assemblePlaystoreDebug` and ktlint 1.7.1 both clean.

| # | Scenario | Result | Screenshot |
| --- | --- | --- | --- |
| 1 | S02E06 last watched, check S02E10 | E10 marked, prompt shown | <img width="200" alt="02-prompt-watched-until-here" src="https://github.com/user-attachments/assets/20eb9c6f-66ee-4f44-a7ac-7e23839475bb" /> |
| 2 | Confirm the prompt | Sheet lists "3 episodes" (E07, E08, E09); anchor excluded | <img width="200" alt="03-sheet-3-episodios-ancora-fora" src="https://github.com/user-attachments/assets/8722519e-c849-4a65-add3-9cfcf8f21334" /> |
| 3 | Confirm the sheet | E07-E09 marked, gap closed | <img width="200" alt="04-lacuna-preenchida" src="https://github.com/user-attachments/assets/92b70e47-f103-4caf-9f08-414a2ea7e492" /> |
| 4 | Check the next episode, no gap | Marked, no prompt | <img width="200" alt="05-sem-lacuna-sem-prompt" src="https://github.com/user-attachments/assets/1930d85d-8e76-4f40-965e-dc7d18739633" /> |
| 5 | Previous season incomplete, check S03E11 | Prompt shown from the earlier season's gap | <img width="200" alt="06-prompt-lacuna-temporada-anterior" src="https://github.com/user-attachments/assets/b004fbd5-8a36-44ee-975a-1d9ba31e8c63" /> |
| 6 | Cancel the prompt | Only the checked episode stays marked | <img width="200" alt="07-cancelar-mantem-so-o-ancora" src="https://github.com/user-attachments/assets/f05498e4-476c-4959-a509-cd05dea25818" /> |
| 7 | All seasons, overflow > Track > date | Same prompt after the date is applied | <img width="200" alt="08-all-seasons-track-menu-prompt" src="https://github.com/user-attachments/assets/a51331e1-6148-4c96-91f6-5cc58ced0303" /> |

Not exercised on device: specials (guarded by `episode.season <= 0`) and the re-watch path, since the seasons list only renders a check for an episode that is not watched yet; the `!wasWatched` guard is there for the overflow **Track** entry.

Closes: #359 
