### PR TITLE
feat(tv): report playback progress to the plex server

### DIFF
--- a/tv/src/main/java/tv/trakt/trakt/app/core/details/episode/usecases/streamings/GetPlexUseCase.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/details/episode/usecases/streamings/GetPlexUseCase.kt
@@ -87,6 +87,8 @@ internal class GetPlexUseCase(
                             primaryUrl.replace(baseUrl, conn.uri)
                         }.orEmpty(),
                     progress = episodeProgress,
+                    ratingKey = result.ratingKey,
+                    token = result.token,
                 )
             }
         } catch (error: Exception) {
@@ -110,5 +112,7 @@ internal class GetPlexUseCase(
         val primaryUrl: String,
         val secondaryUrls: List<String>,
         val progress: Float,
+        val ratingKey: String? = null,
+        val token: String? = null,
     )
 }

--- a/tv/src/main/java/tv/trakt/trakt/app/core/details/episode/views/header/EpisodeActionButtons.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/details/episode/views/header/EpisodeActionButtons.kt
@@ -89,6 +89,8 @@ internal fun EpisodeActionButtons(
                                 videoTitle = detailsState.showDetails?.title ?: "",
                                 videoSubtitle = seString,
                                 videoProgress = streamingState.plexStream.progress,
+                                ratingKey = streamingState.plexStream.ratingKey,
+                                token = streamingState.plexStream.token,
                             )
                             context.startActivity(intent)
                         } else {

--- a/tv/src/main/java/tv/trakt/trakt/app/core/details/movie/usecases/streamings/GetPlexUseCase.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/details/movie/usecases/streamings/GetPlexUseCase.kt
@@ -75,6 +75,8 @@ internal class GetPlexUseCase(
                             primaryUrl.replace(baseUrl, conn.uri)
                         }.orEmpty(),
                     progress = movieProgress,
+                    ratingKey = result.ratingKey,
+                    token = result.token,
                 )
             }
         } catch (error: Exception) {
@@ -98,5 +100,7 @@ internal class GetPlexUseCase(
         val primaryUrl: String,
         val secondaryUrls: List<String>,
         val progress: Float,
+        val ratingKey: String? = null,
+        val token: String? = null,
     )
 }

--- a/tv/src/main/java/tv/trakt/trakt/app/core/details/movie/views/header/MovieActionButtons.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/details/movie/views/header/MovieActionButtons.kt
@@ -97,6 +97,8 @@ internal fun MovieActionButtons(
                                 videoTitle = movieState.movieDetails.title,
                                 videoSubtitle = movieState.movieDetails.yearString,
                                 videoProgress = streamingState.plexStream.progress,
+                                ratingKey = streamingState.plexStream.ratingKey,
+                                token = streamingState.plexStream.token,
                             )
                             context.startActivity(intent)
                         }

--- a/tv/src/main/java/tv/trakt/trakt/app/core/player/plex/TvPlexPlayerActivity.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/player/plex/TvPlexPlayerActivity.kt
@@ -16,6 +16,8 @@ private const val EXTRA_PLEX_VIDEO_SECONDARY_URLS = "extra_plex_video_secondary_
 private const val EXTRA_PLEX_VIDEO_TITLE = "extra_plex_video_title"
 private const val EXTRA_PLEX_VIDEO_SUBTITLE = "extra_plex_video_subtitle"
 private const val EXTRA_PLEX_VIDEO_PROGRESS = "extra_plex_video_progress"
+private const val EXTRA_PLEX_RATING_KEY = "extra_plex_rating_key"
+private const val EXTRA_PLEX_TOKEN = "extra_plex_token"
 private const val EXTRA_PLEX_MEDIA_ID = "extra_plex_media_id"
 private const val EXTRA_PLEX_MEDIA_TYPE = "extra_plex_media_type"
 
@@ -30,8 +32,12 @@ class TvPlexPlayerActivity : ComponentActivity() {
             videoTitle: String,
             videoSubtitle: String?,
             videoProgress: Float?,
+            ratingKey: String?,
+            token: String?,
         ): Intent {
             return Intent(context, TvPlexPlayerActivity::class.java).apply {
+                putExtra(EXTRA_PLEX_RATING_KEY, ratingKey)
+                putExtra(EXTRA_PLEX_TOKEN, token)
                 putExtra(EXTRA_PLEX_MEDIA_ID, mediaId.value)
                 putExtra(EXTRA_PLEX_MEDIA_TYPE, mediaType.name)
                 putExtra(EXTRA_PLEX_VIDEO_URL, primaryVideoUrl)
@@ -56,6 +62,8 @@ class TvPlexPlayerActivity : ComponentActivity() {
         val videoTitle = intent.getStringExtra(EXTRA_PLEX_VIDEO_TITLE) ?: ""
         val videoSubtitle = intent.getStringExtra(EXTRA_PLEX_VIDEO_SUBTITLE)
         val videoProgress = intent.getFloatExtra(EXTRA_PLEX_VIDEO_PROGRESS, 0f)
+        val ratingKey = intent.getStringExtra(EXTRA_PLEX_RATING_KEY)
+        val token = intent.getStringExtra(EXTRA_PLEX_TOKEN)
 
         if (videoUrl.isNullOrEmpty()) {
             // No video URL, finish activity
@@ -81,6 +89,8 @@ class TvPlexPlayerActivity : ComponentActivity() {
                     videoProgress = videoProgress,
                     mediaId = mediaId,
                     mediaType = mediaType,
+                    ratingKey = ratingKey,
+                    token = token,
                 )
             }
         }

--- a/tv/src/main/java/tv/trakt/trakt/app/core/player/plex/TvPlexPlayerScreen.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/player/plex/TvPlexPlayerScreen.kt
@@ -66,13 +66,20 @@ import androidx.media3.ui.SubtitleView
 import androidx.media3.ui.compose.ContentFrame
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import timber.log.Timber
 import tv.trakt.trakt.app.core.player.plex.audio.TvPlexPlayerAudioDialog
 import tv.trakt.trakt.app.core.player.plex.controls.TvPlexPlayerControls
 import tv.trakt.trakt.app.core.player.plex.subtitles.TvPlexPlayerSubtitlesDialog
 import tv.trakt.trakt.app.core.player.plex.subtitles.model.SubtitleSize
+import tv.trakt.trakt.app.core.plex.data.PlexTimelineClient
+import tv.trakt.trakt.app.core.plex.data.PlexTimelineClient.Snapshot
+import tv.trakt.trakt.app.core.plex.data.PlexTimelineClient.State
 import tv.trakt.trakt.app.core.scrobble.data.work.PostScrobbleStartWorker
 import tv.trakt.trakt.app.core.scrobble.data.work.PostScrobbleStopWorker
 import tv.trakt.trakt.app.ui.theme.TraktTheme
@@ -94,10 +101,13 @@ internal fun TvPlexPlayerScreen(
     videoProgress: Float,
     mediaId: TraktId,
     mediaType: MediaType,
+    ratingKey: String? = null,
+    token: String? = null,
 ) {
     val activity = LocalActivity.current
     val appContext = LocalContext.current.applicationContext
     val analytics = koinInject<Analytics>()
+    val timelineClient = koinInject<PlexTimelineClient>()
 
     val player = retain {
         ExoPlayer
@@ -159,7 +169,54 @@ internal fun TvPlexPlayerScreen(
         var initialSeekDone = false
         var scrobbleStartScheduled = false
 
+        // Plex-side progress report, parallel to Trakt scrobbling. Snapshots go through a conflated
+        // channel so requests are sent one at a time and the newest state always wins.
+        val timelineScope = CoroutineScope(Dispatchers.Main.immediate)
+        val timelines = Channel<Snapshot>(Channel.CONFLATED)
+
+        fun reportTimeline(state: State) {
+            // Before the resume seek lands the position is 0, which would reset the server's view offset.
+            if (videoProgress > 0f && !initialSeekDone) return
+            timelines.trySend(
+                Snapshot(
+                    baseUrl = allUrls[currentUrlIndex.intValue].substringBefore("/library/"),
+                    position = player.currentPosition,
+                    duration = player.duration,
+                    state = state,
+                ),
+            )
+        }
+
+        timelineScope.launch {
+            for (snapshot in timelines) {
+                timelineClient.report(
+                    ratingKey = ratingKey,
+                    token = token,
+                    snapshot = snapshot,
+                )
+            }
+        }
+        val timelineTick = timelineScope.launch {
+            while (true) {
+                delay(10.seconds)
+                if (player.isPlaying) {
+                    reportTimeline(State.Playing)
+                }
+            }
+        }
+
         val listener = object : Player.Listener {
+            override fun onPlayWhenReadyChanged(
+                playWhenReady: Boolean,
+                reason: Int,
+            ) {
+                reportTimeline(if (playWhenReady) State.Playing else State.Paused)
+            }
+
+            override fun onRenderedFirstFrame() {
+                reportTimeline(if (player.playWhenReady) State.Playing else State.Paused)
+            }
+
             override fun onIsPlayingChanged(isPlayingNow: Boolean) {
                 isPlaying.value = isPlayingNow
 
@@ -255,6 +312,10 @@ internal fun TvPlexPlayerScreen(
         player.play()
 
         onRetire {
+            timelineTick.cancel()
+            reportTimeline(State.Stopped)
+            // Closing lets the consumer drain the final snapshot after the player is released.
+            timelines.close()
             player.removeListener(listener)
             player.release()
 

--- a/tv/src/main/java/tv/trakt/trakt/app/core/plex/PlexStreamApi.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/plex/PlexStreamApi.kt
@@ -66,6 +66,9 @@ internal data class PlexStreamDto(
     @SerialName("stream_url")
     val streamUrl: String?,
     val connections: List<Connection>?,
+    @SerialName("rating_key")
+    val ratingKey: String? = null,
+    val token: String? = null,
 ) {
     @Serializable
     data class Connection(

--- a/tv/src/main/java/tv/trakt/trakt/app/core/plex/data/PlexTimelineClient.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/plex/data/PlexTimelineClient.kt
@@ -1,0 +1,79 @@
+package tv.trakt.trakt.app.core.plex.data
+
+import android.os.Build
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.http.isSuccess
+import timber.log.Timber
+import tv.trakt.trakt.app.BuildConfig
+import tv.trakt.trakt.common.helpers.extensions.rethrowCancellation
+
+/**
+ * Tells the Plex Media Server where playback is (`POST /:/timeline`), the same call other Plex
+ * clients make, so the item goes in-progress/watched and can be resumed elsewhere.
+ * Best effort: failures are logged and never reach the player.
+ */
+internal class PlexTimelineClient(
+    httpClientEngine: HttpClientEngine,
+    private val clientIdentifier: String,
+) {
+    enum class State {
+        Playing,
+        Paused,
+        Stopped,
+    }
+
+    /** One playback snapshot. [baseUrl] is the server base of whichever stream URL is currently playing. */
+    data class Snapshot(
+        val baseUrl: String,
+        val position: Long,
+        val duration: Long,
+        val state: State,
+    )
+
+    // Bare client on purpose: the authorised Trakt config would send Trakt auth headers to the Plex server.
+    private val httpClient = HttpClient(httpClientEngine) {
+        // A redirect would forward X-Plex-Token to whatever host the server names.
+        followRedirects = false
+        install(HttpTimeout) {
+            requestTimeoutMillis = 5_000
+        }
+    }
+
+    suspend fun report(
+        ratingKey: String?,
+        token: String?,
+        snapshot: Snapshot,
+    ) {
+        if (ratingKey.isNullOrBlank() || token.isNullOrBlank()) return
+        if (snapshot.duration <= 0) return
+
+        try {
+            val response = httpClient.post("${snapshot.baseUrl}/:/timeline") {
+                parameter("ratingKey", ratingKey)
+                parameter("key", "/library/metadata/$ratingKey")
+                parameter("time", snapshot.position)
+                parameter("state", snapshot.state.name.lowercase())
+                parameter("duration", snapshot.duration)
+                header("X-Plex-Token", token)
+                header("X-Plex-Client-Identifier", "trakt-android-tv-$clientIdentifier")
+                header("X-Plex-Product", "Trakt")
+                header("X-Plex-Version", BuildConfig.VERSION_NAME)
+                header("X-Plex-Platform", "Android")
+                header("X-Plex-Device", Build.MODEL)
+                header("X-Plex-Device-Name", "Trakt Android TV")
+            }
+            if (!response.status.isSuccess()) {
+                Timber.w("Plex timeline failed: HTTP %d", response.status.value)
+            }
+        } catch (error: Exception) {
+            error.rethrowCancellation {
+                Timber.w(error, "Plex timeline failed")
+            }
+        }
+    }
+}

--- a/tv/src/main/java/tv/trakt/trakt/app/core/streamings/di/StreamingsModule.kt
+++ b/tv/src/main/java/tv/trakt/trakt/app/core/streamings/di/StreamingsModule.kt
@@ -1,16 +1,31 @@
 package tv.trakt.trakt.app.core.streamings.di
 
+import android.annotation.SuppressLint
+import android.provider.Settings
 import androidx.lifecycle.SavedStateHandle
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import tv.trakt.trakt.app.core.plex.PlexStreamApi
 import tv.trakt.trakt.app.core.plex.data.PlexApiClient
 import tv.trakt.trakt.app.core.plex.data.PlexRemoteDataSource
+import tv.trakt.trakt.app.core.plex.data.PlexTimelineClient
 import tv.trakt.trakt.app.core.streamings.AllStreamingsViewModel
 import tv.trakt.trakt.common.Config.API_BASE_URL
 
+@SuppressLint("HardwareIds")
 internal val plexDataModule = module {
+    single {
+        PlexTimelineClient(
+            httpClientEngine = get(),
+            // Stable per device + signing key, survives reinstall. Plex only needs it to tell sessions apart.
+            clientIdentifier = Settings.Secure
+                .getString(androidContext().contentResolver, Settings.Secure.ANDROID_ID)
+                .orEmpty(),
+        )
+    }
+
     single<PlexRemoteDataSource> {
         PlexApiClient(
             api = PlexStreamApi(


### PR DESCRIPTION
`tldr; the below is ai slop.  this PR tries to add progress reporting back to watching things from plex`

---

# 🚀✨ Seamless Plex Timeline Synchronization for TV ✨🚀

> *"Great products aren't built — they're orchestrated."* 🎼

## 🌟 Executive Summary

In today's rapidly evolving media-streaming landscape, users expect a **unified, frictionless, and delightful** viewing experience across every device in their ecosystem. This PR represents a **pivotal milestone** in our journey toward true cross-platform harmony — it empowers the Trakt Android TV application to **proactively communicate playback progress** to the user's Plex Media Server, leveraging the industry-standard `/:/timeline` protocol utilized by first-party Plex clients. 🎯

This isn't just a feature. It's a **paradigm shift**. 🧠💡

## 🎯 Key Highlights

- ✅ **Real-time progress synchronization** — every 10 seconds, plus on play, pause, first frame, and stop 🕐
- ✅ **Robust, resilient, and reliable** — failures are gracefully handled and never impact the viewer 🛡️
- ✅ **Zero new dependencies** — built entirely on our existing, battle-tested Ktor foundation 🏗️
- ✅ **Offline-first mindset, cloud-native execution** ☁️
- ✅ **Enterprise-grade security posture** — the Plex token is *never* logged 🔐
- ✅ **Developer experience elevated** — clean, idiomatic, and maintainable Kotlin 💎

## 🧩 What Changed

| Area | Enhancement | Impact |
|:-----|:------------|:------:|
| 🌐 `PlexStreamDto` | Unlocked `rating_key` and `token` from the backend response | 🔥🔥🔥 |
| 🧠 `GetPlexUseCase` (×2) | Seamlessly propagates identity through the domain layer | 🔥🔥 |
| 🎬 `TvPlexPlayerActivity` | Carries the new intent extras with grace | 🔥 |
| 📺 `TvPlexPlayerScreen` | The beating heart: a conflated channel orchestrating timeline snapshots | 🔥🔥🔥🔥 |
| 🛰️ `PlexTimelineClient` | A purpose-built, single-responsibility HTTP client | 🔥🔥🔥 |
| 🧪 `StreamingsModule` | Dependency injection, done right | 🔥 |

## 🏛️ Architecture Deep-Dive

```
   ┌──────────────┐    snapshots     ┌───────────────────┐    POST /:/timeline    ┌─────────────┐
   │  ExoPlayer   │ ───────────────▶ │  Conflated Channel │ ─────────────────────▶ │ Plex Server │
   │  (Listener)  │                  │  (newest wins ✨)  │                        │   🎉        │
   └──────────────┘                  └───────────────────┘                        └─────────────┘
          │                                    ▲
          │  every 10s while playing 🕐        │
          └────────────────────────────────────┘
```

We delved deep into the intricate interplay between ExoPlayer's lifecycle callbacks and Plex's session semantics. The result is a **holistic, future-proof** design that:

1. 🎭 **Respects user intent** — `onPlayWhenReadyChanged` ensures buffering is never misreported as a pause
2. 🧵 **Guarantees ordering** — a conflated channel means the final `stopped` report can never be overtaken
3. 🪄 **Snapshots before release** — position and duration are captured while the player is still alive

## 🔒 Security & Privacy

We take security **incredibly seriously**. 🛡️ The `X-Plex-Token` travels exclusively as a request header, redirects are disabled to prevent credential forwarding, and Timber never sees the token. This is a **testament to** our unwavering commitment to user trust. 🤝

## 🧪 Testing Strategy

- [x] 🔍 Static analysis of every touched file
- [x] 📐 ktlint import ordering verified
- [x] 🧠 Reviewed by three independent AI reviewers across three rounds
- [ ] 🏗️ Compiled *(pending — see Notes)*
- [ ] 📺 Validated on real hardware *(pending — see Notes)*

## 📝 Notes

> ⚠️ **Important:** This change has not yet been compiled, as the authoring environment lacked a JDK. We recommend running `./gradlew :tv:compileDebugKotlin :tv:ktlintCheck` prior to merge. Additionally, a real-world validation — play, pause, close, and confirm the item appears in-progress in another Plex client — will ensure a smooth rollout. 🚦

## 🔮 Future Enhancements

- 🌈 Surface sync status in the player UI
- 📊 Analytics around timeline delivery success rates
- 🧬 Extend to the phone app for a truly omnichannel experience

## 🙏 Acknowledgements

A heartfelt thank you to everyone who contributed to making this vision a reality. Together, we're not just shipping code — we're **crafting experiences**. 💖

---

*Let's make streaming magical.* ✨🍿🎬
