### PR TITLE
feat(app): extend the rate prompt to shows

### DIFF
--- a/app/src/main/java/tv/trakt/trakt/core/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/calendar/CalendarViewModel.kt
@@ -371,7 +371,7 @@ internal class CalendarViewModel(
                     date = customDate?.analyticsStrings,
                 )
 
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     errorState.update { error }

--- a/app/src/main/java/tv/trakt/trakt/core/discover/sections/releases/all/AllReleasesViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/discover/sections/releases/all/AllReleasesViewModel.kt
@@ -368,7 +368,7 @@ internal class AllReleasesViewModel(
                     date = customDate?.analyticsStrings,
                 )
 
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     errorState.update { error }

--- a/app/src/main/java/tv/trakt/trakt/core/home/di/HomeModule.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/home/di/HomeModule.kt
@@ -116,6 +116,7 @@ internal val homeModule = module {
             filterManager = get(),
             sessionManager = get(),
             collapsingManager = get(),
+            ratePromptManager = get(),
             checkInManager = get(),
             analytics = get(),
         )

--- a/app/src/main/java/tv/trakt/trakt/core/home/sections/upnext/HomeUpNextViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/home/sections/upnext/HomeUpNextViewModel.kt
@@ -56,6 +56,7 @@ import tv.trakt.trakt.core.home.sections.upnext.HomeUpNextState.ItemsState
 import tv.trakt.trakt.core.home.sections.upnext.features.all.data.local.UpNextUpdates
 import tv.trakt.trakt.core.home.sections.upnext.features.all.data.local.UpNextUpdates.Source.Widget
 import tv.trakt.trakt.core.home.sections.upnext.usecases.GetUpNextUseCase
+import tv.trakt.trakt.core.ratings.rateprompt.RatePromptManager
 import tv.trakt.trakt.core.summary.episodes.data.EpisodeDetailsUpdates
 import tv.trakt.trakt.core.summary.episodes.data.EpisodeDetailsUpdates.Source.Calendar
 import tv.trakt.trakt.core.summary.episodes.data.EpisodeDetailsUpdates.Source.History
@@ -86,6 +87,7 @@ internal class HomeUpNextViewModel(
     private val filterManager: GlobalFilterManager,
     private val sessionManager: SessionManager,
     private val collapsingManager: CollapsingManager,
+    private val ratePromptManager: RatePromptManager,
     private val analytics: Analytics,
 ) : ViewModel() {
     private val initialState = HomeUpNextState()
@@ -316,6 +318,7 @@ internal class HomeUpNextViewModel(
                 itemsOrder = itemsState.value.items?.map { "${it.mediaId}-${it.type}" }
 
                 appReviewUseCase.incrementCount()
+                ratePromptManager.checkRecentlyWatched()
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     errorState.update { error }

--- a/app/src/main/java/tv/trakt/trakt/core/home/sections/watchlist/HomeWatchlistViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/home/sections/watchlist/HomeWatchlistViewModel.kt
@@ -459,7 +459,7 @@ internal class HomeWatchlistViewModel(
         viewModelScope.launch {
             try {
                 loadUserProgressUseCase.loadMoviesProgress()
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     Timber.recordError(error)

--- a/app/src/main/java/tv/trakt/trakt/core/home/sections/watchlist/features/all/AllHomeWatchlistViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/home/sections/watchlist/features/all/AllHomeWatchlistViewModel.kt
@@ -549,7 +549,7 @@ internal class AllHomeWatchlistViewModel(
         viewModelScope.launch {
             try {
                 loadUserProgressUseCase.loadMoviesProgress()
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     Timber.recordError(error)

--- a/app/src/main/java/tv/trakt/trakt/core/lists/sections/personal/features/context/movie/ListMovieContextViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/lists/sections/personal/features/context/movie/ListMovieContextViewModel.kt
@@ -234,7 +234,7 @@ internal class ListMovieContextViewModel(
                     ids = setOf(movie.ids.trakt),
                 )
                 watchlistUpdates.notifyUpdate(Source.Default)
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
 
                 analytics.progress.logAddWatchedMedia(
                     mediaType = "movie",

--- a/app/src/main/java/tv/trakt/trakt/core/lists/sections/watchlist/features/all/AllWatchlistViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/lists/sections/watchlist/features/all/AllWatchlistViewModel.kt
@@ -450,7 +450,7 @@ internal class AllWatchlistViewModel(
         viewModelScope.launch {
             try {
                 loadUserProgressUseCase.loadMoviesProgress()
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     Timber.recordError(error)

--- a/app/src/main/java/tv/trakt/trakt/core/lists/sections/watchlist/features/context/movies/WatchlistMovieContextViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/lists/sections/watchlist/features/context/movies/WatchlistMovieContextViewModel.kt
@@ -87,7 +87,7 @@ internal class WatchlistMovieContextViewModel(
                 userWatchlistMinLocalSource.removeMovies(setOf(movieId))
 
                 loadProgressUseCase.loadMoviesProgress()
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
 
                 analytics.progress.logAddWatchedMedia(
                     mediaType = "movie",

--- a/app/src/main/java/tv/trakt/trakt/core/main/MainScreen.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/main/MainScreen.kt
@@ -114,6 +114,8 @@ import tv.trakt.trakt.core.notifications.data.work.INTENT_NOTIFICATION_TRIVIA_EX
 import tv.trakt.trakt.core.notifications.model.NotificationIntentExtras
 import tv.trakt.trakt.core.profile.navigation.ProfileDestination
 import tv.trakt.trakt.core.profile.navigation.navigateToProfile
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia.MovieMedia
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia.ShowMedia
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState.AskSuppress
 import tv.trakt.trakt.core.search.model.SearchInput
 import tv.trakt.trakt.core.search.navigation.SearchDestination
@@ -415,9 +417,14 @@ private fun MainScreenContent(
                             MainRatePromptView(
                                 state = state,
                                 onMediaClick = {
-                                    navController.navigateToMovie(
-                                        movieId = it.movie.ids.trakt,
-                                    )
+                                    when (it) {
+                                        is MovieMedia -> navController.navigateToMovie(
+                                            movieId = it.movie.ids.trakt,
+                                        )
+                                        is ShowMedia -> navController.navigateToShow(
+                                            showId = it.show.ids.trakt,
+                                        )
+                                    }
                                 },
                             )
 

--- a/app/src/main/java/tv/trakt/trakt/core/main/MainViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/main/MainViewModel.kt
@@ -331,7 +331,7 @@ internal class MainViewModel(
     private fun loadRatePrompt() {
         viewModelScope.launch {
             try {
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
             } catch (error: Exception) {
                 error.rethrowCancellation {
                     Timber.recordError(error)

--- a/app/src/main/java/tv/trakt/trakt/core/main/ui/rateprompt/MainRatePromptView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/main/ui/rateprompt/MainRatePromptView.kt
@@ -17,7 +17,7 @@ import org.koin.core.parameter.parametersOf
 import tv.trakt.trakt.LocalRatePromptVisibility
 import tv.trakt.trakt.core.main.MainState
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia
-import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState.UnratedMovies
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState.UnratedMedia
 import tv.trakt.trakt.core.ratings.rateprompt.ui.RatePromptView
 import tv.trakt.trakt.ui.theme.TraktTheme
 
@@ -29,12 +29,11 @@ internal fun ColumnScope.MainRatePromptView(
     val localVisibility = LocalRatePromptVisibility.current
 
     val ratePrompt = state.ratePrompt
-    val ratePromptMovies = (ratePrompt as? UnratedMovies)?.movies.orEmpty()
-    val ratePromptFavorites = (ratePrompt as? UnratedMovies)?.favorites.orEmpty()
+    val ratePromptMedia = (ratePrompt as? UnratedMedia)?.media.orEmpty()
 
     AnimatedVisibility(
-        visible = remember(ratePrompt, ratePromptMovies, localVisibility.value) {
-            ratePrompt is UnratedMovies && localVisibility.value
+        visible = remember(ratePrompt, ratePromptMedia, localVisibility.value) {
+            ratePrompt is UnratedMedia && localVisibility.value
         },
         enter = fadeIn(tween(250)) + slideInVertically(initialOffsetY = { it / 10 }),
         exit = fadeOut(tween(200)),
@@ -42,26 +41,14 @@ internal fun ColumnScope.MainRatePromptView(
             .fillMaxWidth()
             .padding(horizontal = TraktTheme.spacing.mainPageHorizontalSpace - 8.dp),
     ) {
-        ratePromptMovies
+        ratePromptMedia
             .firstOrNull()
-            ?.let { movie ->
-                val media = RatePromptMedia(
-                    movie = movie,
-                    favorite = ratePromptFavorites.contains(movie.ids.trakt),
-                )
-
-                val moreMedia = ratePromptMovies
-                    .filter { it.ids.trakt != movie.ids.trakt }
-                    .map { movie ->
-                        RatePromptMedia(
-                            movie = movie,
-                            favorite = ratePromptFavorites.contains(movie.ids.trakt),
-                        )
-                    }
+            ?.let { media ->
+                val moreMedia = ratePromptMedia.drop(1)
 
                 RatePromptView(
                     viewModel = koinViewModel(
-                        key = media.movie.ids.trakt.value.toString(),
+                        key = "${media.mediaType.value}-${media.id.value}",
                     ) {
                         parametersOf(media, moreMedia)
                     },

--- a/app/src/main/java/tv/trakt/trakt/core/movies/ui/context/MovieContextViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/movies/ui/context/MovieContextViewModel.kt
@@ -236,7 +236,7 @@ internal class MovieContextViewModel(
                 )
 
                 watchlistUpdates.notifyUpdate(Default)
-                ratePromptManager.checkMovies()
+                ratePromptManager.checkRecentlyWatched()
 
                 analytics.progress.logAddWatchedMedia(
                     mediaType = "movie",

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/di/RatingsModule.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/di/RatingsModule.kt
@@ -33,6 +33,7 @@ import tv.trakt.trakt.core.ratings.rateprompt.DefaultRatePromptManager
 import tv.trakt.trakt.core.ratings.rateprompt.RatePromptManager
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia
 import tv.trakt.trakt.core.ratings.rateprompt.ui.RatePromptViewModel
+import tv.trakt.trakt.core.ratings.rateprompt.usecases.IsShowRatingCandidateUseCase
 
 internal const val RATINGS_PREFERENCES = "ratings_preferences"
 
@@ -56,8 +57,11 @@ internal val ratingsDataModule = module {
             userFavoritesUseCase = get(),
             updateUserSettingsUseCase = get(),
             userHistoryDataSource = get(),
+            isShowRatingCandidateUseCase = get(),
         )
     }
+
+    factoryOf(::IsShowRatingCandidateUseCase)
 }
 
 internal val ratingsModule = module {

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/DefaultRatePromptManager.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/DefaultRatePromptManager.kt
@@ -5,8 +5,8 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -26,32 +26,50 @@ import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
 import tv.trakt.trakt.common.helpers.extensions.recordError
 import tv.trakt.trakt.common.helpers.extensions.rethrowCancellation
 import tv.trakt.trakt.common.helpers.extensions.toInstant
+import tv.trakt.trakt.common.model.Episode
 import tv.trakt.trakt.common.model.Movie
+import tv.trakt.trakt.common.model.Show
 import tv.trakt.trakt.common.model.TraktId
 import tv.trakt.trakt.common.model.fromDto
+import tv.trakt.trakt.common.model.ratings.UserRating
 import tv.trakt.trakt.core.checkin.data.CheckInManager
 import tv.trakt.trakt.core.home.sections.activity.model.HomeActivityItem
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia.MovieMedia
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia.ShowMedia
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState.AskSuppress
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState.Idle
-import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState.UnratedMovies
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState.UnratedMedia
+import tv.trakt.trakt.core.ratings.rateprompt.usecases.IsShowRatingCandidateUseCase
 import tv.trakt.trakt.core.settings.usecases.UpdateUserSettingsUseCase
 import tv.trakt.trakt.core.user.usecases.ratings.LoadUserRatingsUseCase
+import java.time.Instant
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinInstant
 
 private const val USER_DISMISS_LIMIT = 5
-private const val UNRATED_MOVIES_LIMIT = 5
+private const val UNRATED_MEDIA_LIMIT = 5
+private const val MOVIE_HISTORY_LIMIT = 10
+
+/**
+ * Episodes are pulled over the whole binge window so a single request answers both
+ * "watched recently" and "how many episodes of this show this week".
+ */
+private const val EPISODE_HISTORY_LIMIT = 100
+
 private val RECENTLY_WATCHED_DURATION = 24.hours.toJavaDuration()
+private val SHOW_BINGE_DURATION = 7.days.toJavaDuration()
 
 private val KEY_USER_DISMISS_COUNT = intPreferencesKey("key_dismiss_count")
-private val KEY_DISMISSED_MOVIES = stringSetPreferencesKey("key_dismissed_movies")
+private val KEY_DISMISSED_MEDIA = stringSetPreferencesKey("key_dismissed_media")
 
 /**
  * Default implementation of [RatePromptManager] that checks the user's ratings and favorites to determine
- * if they should be prompted to rate recently watched movies. It also tracks user dismissals and suppresses
- * the prompt after a certain number of dismissals.
+ * if they should be prompted to rate recently watched movies and shows. It also tracks user dismissals and
+ * suppresses the prompt after a certain number of dismissals.
  */
 internal class DefaultRatePromptManager(
     private val sessionManager: SessionManager,
@@ -61,11 +79,12 @@ internal class DefaultRatePromptManager(
     private val userFavoritesUseCase: LoadUserFavoritesUseCase,
     private val updateUserSettingsUseCase: UpdateUserSettingsUseCase,
     private val userHistoryDataSource: UserHistoryRemoteDataSource,
+    private val isShowRatingCandidateUseCase: IsShowRatingCandidateUseCase,
 ) : RatePromptManager {
     private val state = MutableStateFlow<RatePromptState>(Idle)
     private var moviesFavorites = emptyList<FavoriteItem>()
 
-    override suspend fun checkMovies() {
+    override suspend fun checkRecentlyWatched() {
         if (!sessionManager.isAuthenticated()) {
             Timber.d("User is not authenticated, skipping rate prompt.")
             return
@@ -78,12 +97,18 @@ internal class DefaultRatePromptManager(
 
         try {
             val nowUtc = nowUtcInstant()
-            val durationWindow = nowUtc.minus(RECENTLY_WATCHED_DURATION)
+            val recentlyWatchedWindow = nowUtc.minus(RECENTLY_WATCHED_DURATION)
+            val bingeWindow = nowUtc.minus(SHOW_BINGE_DURATION)
 
             coroutineScope {
-                val ratingsCase = async {
+                val movieRatingsAsync = async {
                     if (!userRatingsUseCase.isMoviesLoaded()) {
                         userRatingsUseCase.loadMovies()
+                    }
+                }
+                val showRatingsAsync = async {
+                    if (!userRatingsUseCase.isShowsLoaded()) {
+                        userRatingsUseCase.loadShows()
                     }
                 }
                 val favoritesAsync = async {
@@ -91,23 +116,37 @@ internal class DefaultRatePromptManager(
                         userFavoritesUseCase.loadMovies()
                     }
                 }
-                awaitAll(ratingsCase, favoritesAsync)
+                awaitAll(movieRatingsAsync, showRatingsAsync, favoritesAsync)
             }
 
             val moviesRatings = userRatingsUseCase.loadLocalMovies()
+            val showsRatings = userRatingsUseCase.loadLocalShows()
             moviesFavorites = userFavoritesUseCase.loadLocalMovies()
 
-            val moviesDismissed = dataStore.data
-                .map { it[KEY_DISMISSED_MOVIES] ?: emptySet() }
-                .firstOrNull() ?: emptySet()
+            val dismissed = loadDismissedMedia()
 
-            // Only consider movies that the user hasn't rated, favorite, or dismissed,
-            // and were watched within the recently watched duration.
-            val movies = userHistoryDataSource.getMoviesHistory(
-                page = 1,
-                limit = 10,
-                filters = null,
-            ).asyncMap {
+            val (movieHistory, episodeHistory) = coroutineScope {
+                val moviesAsync = async {
+                    userHistoryDataSource.getMoviesHistory(
+                        page = 1,
+                        limit = MOVIE_HISTORY_LIMIT,
+                        filters = null,
+                        from = recentlyWatchedWindow.toKotlinInstant(),
+                    )
+                }
+                val episodesAsync = async {
+                    userHistoryDataSource.getEpisodesHistory(
+                        page = 1,
+                        limit = EPISODE_HISTORY_LIMIT,
+                        filters = null,
+                        from = bingeWindow.toKotlinInstant(),
+                    )
+                }
+
+                moviesAsync.await() to episodesAsync.await()
+            }
+
+            val movieItems = movieHistory.asyncMap {
                 HomeActivityItem.MovieItem(
                     id = it.id,
                     user = null,
@@ -120,31 +159,54 @@ internal class DefaultRatePromptManager(
                         },
                     ),
                 )
-            }.filter {
-                !moviesRatings.contains(it.movie.ids.trakt) &&
-                    !moviesDismissed.contains(it.movie.ids.trakt.value.toString()) &&
-                    checkInManager.isActiveMovie()?.movie?.ids?.trakt != it.movie.ids.trakt &&
-                    it.activityAt >= durationWindow
-            }.take(UNRATED_MOVIES_LIMIT)
-
-            if (movies.isEmpty()) {
-                Timber.d("No recently watched movies found, skipping rate prompt.")
-                return
-            } else {
-                Timber.d("${movies.size} movies for rate prompt: ${movies.joinToString { it.movie.title }}")
             }
-
-            state.update {
-                UnratedMovies(
-                    movies = movies
-                        .sortedByDescending { it.activityAt }
-                        .map { it.movie }
-                        .toImmutableList(),
-                    favorites = moviesFavorites
-                        .map { it.id }
-                        .toImmutableSet(),
+            val episodeItems = episodeHistory.asyncMap {
+                HomeActivityItem.EpisodeItem(
+                    id = it.id,
+                    user = null,
+                    userRating = null,
+                    activity = it.action.value,
+                    activityAt = it.watchedAt.toInstant(),
+                    episode = Episode.fromDto(
+                        checkNotNull(it.episode) {
+                            "Episode should not be null if type is EPISODE"
+                        },
+                    ),
+                    show = Show.fromDto(
+                        checkNotNull(it.show) {
+                            "Show should not be null if type is EPISODE"
+                        },
+                    ),
                 )
             }
+
+            // Every episode in the payload already sits inside the binge window.
+            val showPlaysInBingeWindow = episodeItems.groupingBy { it.show.ids.trakt }.eachCount()
+
+            // Only consider media the user hasn't rated, favorited, or dismissed, that was watched
+            // within the recently watched duration, and - for shows - that hit a rating moment.
+            val media = (movieItems + episodeItems)
+                .filter { it.activityAt >= recentlyWatchedWindow }
+                .sortedByDescending { it.activityAt }
+                .mapNotNull {
+                    it.toPromptMedia(
+                        moviesRatings = moviesRatings,
+                        showsRatings = showsRatings,
+                        dismissed = dismissed,
+                        showPlaysInBingeWindow = showPlaysInBingeWindow,
+                    )
+                }
+                .distinctBy { it.mediaType to it.id }
+                .take(UNRATED_MEDIA_LIMIT)
+
+            if (media.isEmpty()) {
+                Timber.d("No recently watched media found, skipping rate prompt.")
+                return
+            } else {
+                Timber.d("${media.size} items for rate prompt: ${media.joinToString { it.title }}")
+            }
+
+            state.update { UnratedMedia(media.toImmutableList()) }
         } catch (error: Exception) {
             error.rethrowCancellation {
                 Timber.recordError(error)
@@ -157,24 +219,30 @@ internal class DefaultRatePromptManager(
     }
 
     override suspend fun onUserDismiss(
-        movieId: TraktId,
+        media: RatePromptMedia,
         hasRated: Boolean,
         hasMoreMedia: List<RatePromptMedia>,
     ) {
+        val now = nowUtcInstant()
+
         dataStore.edit {
-            val dismissedMovies = it[KEY_DISMISSED_MOVIES]?.toMutableSet() ?: mutableSetOf()
-            dismissedMovies.add(movieId.value.toString())
-            it[KEY_DISMISSED_MOVIES] = dismissedMovies
+            val dismissedMedia = it.dismissedMedia(now).toMutableSet()
+            dismissedMedia.add(media.toDismissalEntry(now))
+            it[KEY_DISMISSED_MEDIA] = dismissedMedia
 
             if (!hasRated) {
-                // Only increment the dismiss count if the user dismissed the prompt without rating the movie.
+                // Only increment the dismiss count if the user dismissed the prompt without rating the media.
                 val dismissCount = it[KEY_USER_DISMISS_COUNT] ?: 0
                 it[KEY_USER_DISMISS_COUNT] = dismissCount + 1
-                Timber.d("User dismissed rate prompt for movie ${movieId.value}. Dismiss count: ${dismissCount + 1}")
+                Timber.d(
+                    "User dismissed rate prompt for %s. Dismiss count: %s",
+                    media.dismissalKey(),
+                    dismissCount + 1,
+                )
             } else {
-                // If the user rated the movie, reset the dismiss count.
+                // If the user rated the media, reset the dismiss count.
                 it[KEY_USER_DISMISS_COUNT] = 0
-                Timber.d("User rated movie ${movieId.value} after dismissing. Resetting dismiss count.")
+                Timber.d("User rated %s after dismissing. Resetting dismiss count.", media.dismissalKey())
             }
         }
 
@@ -188,16 +256,7 @@ internal class DefaultRatePromptManager(
             if (hasMoreMedia.isEmpty()) {
                 state.update { Idle }
             } else {
-                state.update {
-                    UnratedMovies(
-                        movies = hasMoreMedia
-                            .map { it.movie }
-                            .toImmutableList(),
-                        favorites = moviesFavorites
-                            .map { it.id }
-                            .toImmutableSet(),
-                    )
-                }
+                state.update { UnratedMedia(hasMoreMedia.toImmutableList()) }
             }
         }
     }
@@ -215,5 +274,73 @@ internal class DefaultRatePromptManager(
 
     override fun clear() {
         state.update { Idle }
+    }
+
+    private suspend fun loadDismissedMedia(): Set<String> {
+        val now = nowUtcInstant()
+
+        return dataStore.data
+            .map { it.dismissedMedia(now) }
+            .firstOrNull()
+            .orEmpty()
+            .mapTo(mutableSetOf()) { it.substringBeforeLast(DISMISSAL_SEPARATOR) }
+    }
+
+    /** Dismissals only hold for the recently watched window, mirroring how long the prompt can surface an item. */
+    private fun Preferences.dismissedMedia(now: Instant): Set<String> {
+        val cutoff = now.minus(RECENTLY_WATCHED_DURATION).toEpochMilli()
+
+        return this[KEY_DISMISSED_MEDIA]
+            .orEmpty()
+            .filter { entry ->
+                val dismissedAt = entry.substringAfterLast(DISMISSAL_SEPARATOR).toLongOrNull()
+                dismissedAt != null && dismissedAt >= cutoff
+            }
+            .toSet()
+    }
+
+    private fun RatePromptMedia.toDismissalEntry(now: Instant): String {
+        return "${mediaType.value}$DISMISSAL_SEPARATOR${id.value}$DISMISSAL_SEPARATOR${now.toEpochMilli()}"
+    }
+
+    private fun HomeActivityItem.toPromptMedia(
+        moviesRatings: ImmutableMap<TraktId, UserRating>,
+        showsRatings: ImmutableMap<TraktId, UserRating>,
+        dismissed: Set<String>,
+        showPlaysInBingeWindow: Map<TraktId, Int>,
+    ): RatePromptMedia? {
+        return when (this) {
+            is HomeActivityItem.MovieItem -> {
+                val media = MovieMedia(
+                    movie = movie,
+                    favorite = moviesFavorites.any { it.id == movie.ids.trakt },
+                )
+                val isEligible = !moviesRatings.contains(movie.ids.trakt) &&
+                    !dismissed.contains(media.dismissalKey()) &&
+                    checkInManager.isActiveMovie()?.movie?.ids?.trakt != movie.ids.trakt
+
+                media.takeIf { isEligible }
+            }
+
+            is HomeActivityItem.EpisodeItem -> {
+                val media = ShowMedia(show = show)
+                val isEligible = !showsRatings.contains(show.ids.trakt) &&
+                    !dismissed.contains(media.dismissalKey()) &&
+                    isShowRatingCandidateUseCase(
+                        episodeType = episode.type,
+                        showPlaysInBingeWindow = showPlaysInBingeWindow[show.ids.trakt] ?: 0,
+                    )
+
+                media.takeIf { isEligible }
+            }
+        }
+    }
+
+    private fun RatePromptMedia.dismissalKey(): String {
+        return "${mediaType.value}$DISMISSAL_SEPARATOR${id.value}"
+    }
+
+    private companion object {
+        const val DISMISSAL_SEPARATOR = ":"
     }
 }

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/RatePromptManager.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/RatePromptManager.kt
@@ -1,15 +1,14 @@
 package tv.trakt.trakt.core.ratings.rateprompt
 
 import kotlinx.coroutines.flow.Flow
-import tv.trakt.trakt.common.model.TraktId
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState
 
 internal interface RatePromptManager {
-    suspend fun checkMovies()
+    suspend fun checkRecentlyWatched()
 
     suspend fun onUserDismiss(
-        movieId: TraktId,
+        media: RatePromptMedia,
         hasRated: Boolean,
         hasMoreMedia: List<RatePromptMedia>,
     )

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/model/RatePromptMedia.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/model/RatePromptMedia.kt
@@ -1,8 +1,41 @@
 package tv.trakt.trakt.core.ratings.rateprompt.model
 
+import androidx.compose.runtime.Immutable
+import tv.trakt.trakt.common.model.Images
+import tv.trakt.trakt.common.model.MediaType
 import tv.trakt.trakt.common.model.Movie
+import tv.trakt.trakt.common.model.Show
+import tv.trakt.trakt.common.model.TraktId
 
-data class RatePromptMedia(
-    val movie: Movie,
-    val favorite: Boolean,
-)
+@Immutable
+sealed interface RatePromptMedia {
+    val id: TraktId
+    val mediaType: MediaType
+    val title: String
+    val images: Images?
+
+    /** Favorites are a movie-only affordance; shows never expose the heart. */
+    val favorite: Boolean
+
+    @Immutable
+    data class MovieMedia(
+        val movie: Movie,
+        override val favorite: Boolean,
+    ) : RatePromptMedia {
+        override val id: TraktId get() = movie.ids.trakt
+        override val mediaType: MediaType get() = MediaType.Movie
+        override val title: String get() = movie.title
+        override val images: Images? get() = movie.images
+    }
+
+    @Immutable
+    data class ShowMedia(
+        val show: Show,
+    ) : RatePromptMedia {
+        override val id: TraktId get() = show.ids.trakt
+        override val mediaType: MediaType get() = MediaType.Show
+        override val title: String get() = show.title
+        override val images: Images? get() = show.images
+        override val favorite: Boolean get() = false
+    }
+}

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/model/RatePromptState.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/model/RatePromptState.kt
@@ -1,9 +1,6 @@
 package tv.trakt.trakt.core.ratings.rateprompt.model
 
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableSet
-import tv.trakt.trakt.common.model.Movie
-import tv.trakt.trakt.common.model.TraktId
 
 sealed interface RatePromptState {
     object Idle : RatePromptState
@@ -12,14 +9,13 @@ sealed interface RatePromptState {
 
     object AskSuppress : RatePromptState
 
-    data class UnratedMovies(
-        val movies: ImmutableList<Movie>,
-        val favorites: ImmutableSet<TraktId>,
+    data class UnratedMedia(
+        val media: ImmutableList<RatePromptMedia>,
     ) : RatePromptState
 
     fun isActive(): Boolean {
         return when {
-            this is UnratedMovies -> true
+            this is UnratedMedia -> true
             else -> false
         }
     }

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/ui/RatePromptView.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/ui/RatePromptView.kt
@@ -68,11 +68,23 @@ import tv.trakt.trakt.common.helpers.extensions.onClick
 import tv.trakt.trakt.common.helpers.extensions.onEmptyClick
 import tv.trakt.trakt.common.model.Images.Size
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia.MovieMedia
 import tv.trakt.trakt.core.ratings.ui.UserRatingBar
 import tv.trakt.trakt.resources.R
 import tv.trakt.trakt.ui.theme.HorizontalCheckInImageAspectRatio
 import tv.trakt.trakt.ui.theme.TraktTheme
 import java.time.Instant
+
+private val ratePrompts = listOf(
+    R.string.text_rate_prompt_1,
+    R.string.text_rate_prompt_2,
+    R.string.text_rate_prompt_3,
+    R.string.text_rate_prompt_4,
+    R.string.text_rate_prompt_5,
+    R.string.text_rate_prompt_6,
+    R.string.text_rate_prompt_7,
+    R.string.text_rate_prompt_8,
+)
 
 private val viewShape = RoundedCornerShape(20.dp)
 private val viewPadding = 7.dp
@@ -115,20 +127,15 @@ internal fun RatePromptView(
             ),
     ) {
         ExpandedView(
-            key = media.movie.ids.trakt.toString(),
-            image = media.movie.images?.getFanartUrl(Size.THUMB),
-            title = media.movie.title,
+            key = media.id.toString(),
+            image = media.images?.getFanartUrl(Size.THUMB),
+            title = media.title,
             subtitle = stringResource(
-                remember(media.movie.ids.trakt) {
-                    listOf(
-                        R.string.text_rate_prompt_1,
-                        R.string.text_rate_prompt_2,
-                        R.string.text_rate_prompt_3,
-                    ).random()
-                },
+                remember(media.id) { ratePrompts.random() },
             ),
             rating = state.rating,
             favorite = state.favorite,
+            favoriteVisible = media is MovieMedia,
             favoriteLoading = state.loading.isLoading,
             dismissing = state.dismissing,
             onMediaClick = onMediaClick,
@@ -160,6 +167,7 @@ private fun ExpandedView(
     subtitle: String?,
     rating: Int?,
     favorite: Boolean,
+    favoriteVisible: Boolean,
     favoriteLoading: Boolean,
     dismissing: Instant?,
     modifier: Modifier = Modifier,
@@ -240,7 +248,7 @@ private fun ExpandedView(
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Text(
-                            text = "Rate:",
+                            text = stringResource(R.string.header_rate_now),
                             color = TraktTheme.colors.textPrimary,
                             style = TraktTheme.typography.cardTitle.copy(
                                 fontWeight = W400,
@@ -257,6 +265,7 @@ private fun ExpandedView(
                             textSpacing = 42.dp,
                             rating = rating,
                             favorite = favorite,
+                            favoriteVisible = favoriteVisible,
                             favoriteLoading = favoriteLoading,
                             onRatingDrag = { isDraggingRate = it },
                             onRatingClick = { onRate(it) },
@@ -411,6 +420,7 @@ private fun Preview() {
                         title = "Lord of the Rings: The Fellowship of the Ring",
                         rating = 7,
                         favorite = true,
+                        favoriteVisible = true,
                         favoriteLoading = false,
                         dismissing = null,
                         subtitle = "How did you like it?",

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/ui/RatePromptViewModel.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/ui/RatePromptViewModel.kt
@@ -27,12 +27,12 @@ import tv.trakt.trakt.common.helpers.LoadingState.Loading
 import tv.trakt.trakt.common.helpers.extensions.nowUtcInstant
 import tv.trakt.trakt.common.helpers.extensions.recordError
 import tv.trakt.trakt.common.helpers.extensions.rethrowCancellation
-import tv.trakt.trakt.common.model.MediaType.Movie
 import tv.trakt.trakt.core.favorites.FavoritesUpdates
 import tv.trakt.trakt.core.favorites.FavoritesUpdates.Source.RATE_PROMPT
 import tv.trakt.trakt.core.ratings.data.work.PostRatingWorker
 import tv.trakt.trakt.core.ratings.rateprompt.RatePromptManager
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia
+import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptMedia.MovieMedia
 import tv.trakt.trakt.core.ratings.rateprompt.model.RatePromptState
 import tv.trakt.trakt.core.sync.usecases.UpdateMovieFavoritesUseCase
 import java.time.Instant
@@ -91,8 +91,8 @@ internal class RatePromptViewModel(
 
             PostRatingWorker.scheduleOneTime(
                 appContext = appContext,
-                mediaId = media.movie.ids.trakt,
-                mediaType = Movie,
+                mediaId = media.id,
+                mediaType = media.mediaType,
                 rating = newRating,
             )
         }
@@ -115,14 +115,16 @@ internal class RatePromptViewModel(
 
             PostRatingWorker.scheduleOneTime(
                 appContext = appContext,
-                mediaId = media.movie.ids.trakt,
-                mediaType = Movie,
+                mediaId = media.id,
+                mediaType = media.mediaType,
                 rating = 0, // A rating of 0 indicates removal of rating
             )
         }
     }
 
     fun addToFavorites() {
+        val movie = (media as? MovieMedia)?.movie ?: return
+
         viewModelScope.launch {
             if (!sessionManager.isAuthenticated()) {
                 return@launch
@@ -133,12 +135,12 @@ internal class RatePromptViewModel(
                 dismissingState.update { nowUtcInstant() }
 
                 delay(300) // Small delay to allow UI to settle.
-                updateMovieFavoritesUseCase.addToFavorites(media.movie.ids.trakt)
+                updateMovieFavoritesUseCase.addToFavorites(movie.ids.trakt)
                 userFavoritesLocalSource.addMovies(
                     movies = listOf(
                         FavoriteItem.MovieItem(
                             rank = 0,
-                            movie = media.movie,
+                            movie = movie,
                             listedAt = nowUtcInstant(),
                         ),
                     ),
@@ -162,6 +164,8 @@ internal class RatePromptViewModel(
     }
 
     fun removeFromFavorites() {
+        val movie = (media as? MovieMedia)?.movie ?: return
+
         viewModelScope.launch {
             if (!sessionManager.isAuthenticated()) {
                 return@launch
@@ -172,8 +176,8 @@ internal class RatePromptViewModel(
                 dismissingState.update { nowUtcInstant() }
 
                 delay(300) // Small delay to allow UI to settle.
-                updateMovieFavoritesUseCase.removeFromFavorites(media.movie.ids.trakt)
-                userFavoritesLocalSource.removeMovies(setOf(media.movie.ids.trakt))
+                updateMovieFavoritesUseCase.removeFromFavorites(movie.ids.trakt)
+                userFavoritesLocalSource.removeMovies(setOf(movie.ids.trakt))
                 favoritesUpdates.notifyUpdate(RATE_PROMPT)
 
                 favoriteState.update { false }
@@ -196,7 +200,7 @@ internal class RatePromptViewModel(
         viewModelScope.launch {
             try {
                 ratePromptManager.onUserDismiss(
-                    movieId = media.movie.ids.trakt,
+                    media = media,
                     hasRated = ratingsState.value != null || favoriteState.value,
                     hasMoreMedia = moreMedia,
                 )

--- a/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/usecases/IsShowRatingCandidateUseCase.kt
+++ b/app/src/main/java/tv/trakt/trakt/core/ratings/rateprompt/usecases/IsShowRatingCandidateUseCase.kt
@@ -1,0 +1,30 @@
+package tv.trakt.trakt.core.ratings.rateprompt.usecases
+
+import tv.trakt.trakt.common.model.EpisodeType
+import tv.trakt.trakt.common.model.EpisodeType.MID_SEASON_FINALE
+import tv.trakt.trakt.common.model.EpisodeType.SEASON_FINALE
+import tv.trakt.trakt.common.model.EpisodeType.SERIES_FINALE
+
+internal const val SHOW_BINGE_EPISODE_THRESHOLD = 3
+
+/**
+ * Decides whether a watched episode is a good moment to ask the user to rate its show.
+ *
+ * Deliberately does not reuse [EpisodeType.isFinale]: that property drives the calendar and
+ * up-next tags and excludes [MID_SEASON_FINALE], which still counts as a rating moment here.
+ */
+internal class IsShowRatingCandidateUseCase {
+    operator fun invoke(
+        episodeType: EpisodeType?,
+        showPlaysInBingeWindow: Int,
+    ): Boolean {
+        val isFinale = episodeType in finaleTypes
+        val isBinge = showPlaysInBingeWindow >= SHOW_BINGE_EPISODE_THRESHOLD
+
+        return isFinale || isBinge
+    }
+
+    private companion object {
+        val finaleTypes = setOf(SERIES_FINALE, SEASON_FINALE, MID_SEASON_FINALE)
+    }
+}

--- a/app/src/test/java/tv/trakt/trakt/core/ratings/rateprompt/usecases/IsShowRatingCandidateUseCaseTest.kt
+++ b/app/src/test/java/tv/trakt/trakt/core/ratings/rateprompt/usecases/IsShowRatingCandidateUseCaseTest.kt
@@ -1,0 +1,72 @@
+package tv.trakt.trakt.core.ratings.rateprompt.usecases
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tv.trakt.trakt.common.model.EpisodeType.MID_SEASON_FINALE
+import tv.trakt.trakt.common.model.EpisodeType.MID_SEASON_PREMIERE
+import tv.trakt.trakt.common.model.EpisodeType.SEASON_FINALE
+import tv.trakt.trakt.common.model.EpisodeType.SEASON_PREMIERE
+import tv.trakt.trakt.common.model.EpisodeType.SERIES_FINALE
+import tv.trakt.trakt.common.model.EpisodeType.SERIES_PREMIERE
+
+class IsShowRatingCandidateUseCaseTest {
+    private val useCase = IsShowRatingCandidateUseCase()
+
+    @Test
+    fun `series finale is a candidate`() {
+        assertTrue(useCase(episodeType = SERIES_FINALE, showPlaysInBingeWindow = 0))
+    }
+
+    @Test
+    fun `season finale is a candidate`() {
+        assertTrue(useCase(episodeType = SEASON_FINALE, showPlaysInBingeWindow = 0))
+    }
+
+    @Test
+    fun `mid season finale is a candidate`() {
+        assertTrue(useCase(episodeType = MID_SEASON_FINALE, showPlaysInBingeWindow = 0))
+    }
+
+    @Test
+    fun `premieres are not candidates on their own`() {
+        assertFalse(useCase(episodeType = SERIES_PREMIERE, showPlaysInBingeWindow = 0))
+        assertFalse(useCase(episodeType = SEASON_PREMIERE, showPlaysInBingeWindow = 0))
+        assertFalse(useCase(episodeType = MID_SEASON_PREMIERE, showPlaysInBingeWindow = 0))
+    }
+
+    @Test
+    fun `unknown episode type is not a candidate on its own`() {
+        assertFalse(useCase(episodeType = null, showPlaysInBingeWindow = 0))
+    }
+
+    @Test
+    fun `binge threshold makes a non finale a candidate`() {
+        assertTrue(
+            useCase(
+                episodeType = null,
+                showPlaysInBingeWindow = SHOW_BINGE_EPISODE_THRESHOLD,
+            ),
+        )
+    }
+
+    @Test
+    fun `one play below the binge threshold is not a candidate`() {
+        assertFalse(
+            useCase(
+                episodeType = null,
+                showPlaysInBingeWindow = SHOW_BINGE_EPISODE_THRESHOLD - 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `plays above the binge threshold stay candidates`() {
+        assertTrue(
+            useCase(
+                episodeType = SERIES_PREMIERE,
+                showPlaysInBingeWindow = SHOW_BINGE_EPISODE_THRESHOLD + 5,
+            ),
+        )
+    }
+}

--- a/resources/src/main/res/values/strings.xml
+++ b/resources/src/main/res/values/strings.xml
@@ -1589,6 +1589,11 @@
   <string name="text_rate_prompt_1">How did you like it?</string>
   <string name="text_rate_prompt_2">Your verdict?</string>
   <string name="text_rate_prompt_3">Worth the watch?</string>
+  <string name="text_rate_prompt_4">Thoughts?</string>
+  <string name="text_rate_prompt_5">Out of five stars?</string>
+  <string name="text_rate_prompt_6">How many stars does it earn?</string>
+  <string name="text_rate_prompt_7">Rate your experience.</string>
+  <string name="text_rate_prompt_8">Give it a grade.</string>
   <string name="text_rating_1">Weak</string>
   <string name="text_rating_10">Absolute Cinema!</string>
   <string name="text_rating_2">Terrible</string>


### PR DESCRIPTION
## 🎶 Notes 🎶

Aligns the rate prompt with web, which extended it from movies to shows in
[trakt-web#2196](https://github.com/trakt/trakt-web/pull/2196). Android shipped the
movies-only version and never got the show half, so the same watch history produced a
prompt on web and silence here.

Web is the reference for every behavior below.

### What changed

| web behavior | android before | android now |
| --- | --- | --- |
| merges `/users/me/history/movies` + `/history/episodes` | movies only | both, merged and sorted desc by `watched_at` |
| show is a candidate on `series_finale`, `season_finale`, `mid_season_finale`, or >= 3 episodes in 7 days | no episode path at all | `IsShowRatingCandidateUseCase` |
| `start_at = now - 1d` on the request | no `start_at`, filtered client-side | sends `start_at` |
| per-item dismissals that expire | per-movie-id set, no expiry, ids could collide across types | `key_dismissed_media` entries of `type:id:timestamp`, pruned at 24h |
| 8 randomized prompt lines | 3 | 8 |

Episode history is requested over the whole 7-day binge window so a single payload
answers both "watched in the last 24 hours" and "how many episodes of this show this
week" - no second call just to count plays.

`EpisodeType.isFinale` is deliberately not reused: it excludes `MID_SEASON_FINALE` and
drives the calendar and up-next tags, so the prompt carries its own finale set.

Favorites stay movie-only; the heart is hidden for shows via `favoriteVisible`.

The `"Rate:"` label was a hardcoded English literal and now uses the existing
`header_rate_now` resource, so it picks up the translations already in Crowdin. The five
new prompt variants ship English-only until the next Crowdin sync.

### Behavior notes for review

- Dismissals stored under the old `key_dismissed_movies` key are not migrated. They would
  have expired within a day under the new rule anyway, so at worst a user sees one
  already-dismissed item once.
- `checkMovies()` is renamed to `checkRecentlyWatched()` across its nine call sites.
- `HomeUpNextViewModel.addToHistory` now triggers the check, since marking an episode
  watched from up next is the main way a show becomes a candidate. The other episode
  watch surfaces (episode details, show seasons, activity context, and friends) still
  rely on `MainViewModel.loadData()` picking the prompt up on the next load. Wiring each
  of those is deliberately left out of this PR.

### Not included

- **Poster artwork.** Web shows a poster; the card here is built around a 16:9
  `HorizontalCheckInImageAspectRatio` fanart thumb. Changing it is a design call, not a
  parity fix.
- **`show_rating_prompt` sync.** Already on `main` (`User.settings.ratingPrompts`), so
  there was nothing to align.

## ✅ Verification ✅

Run locally against this branch:

- `./gradlew :app:compileInternalDebugKotlin --rerun-tasks` - passes
- `./gradlew :app:testInternalDebugUnitTest --tests "*IsShowRatingCandidateUseCaseTest*"` - 8/8 pass
- `ktlint` 1.7.1 (the exact binary CI uses) - clean

Not run: instrumented tests, `assembleDebug`, and any on-device check of the prompt.

One caveat worth flagging: `common` does not compile on a freshly generated OpenAPI
client on `main` either. `User.kt:75` reads `dto.user.email` (added in 23d4b6af) but
`openapi/openapi.json` does not declare `email` on `GetUsersSettings200ResponseUser`, so
`openApiGenerate` produces a DTO without it. To get a compile signal for this branch I
temporarily stubbed that one line locally and reverted it before committing - it is not
part of this diff. Worth a look separately.
